### PR TITLE
[Task] Add seeding service for development and test data

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -136,3 +136,20 @@ This will drop the database, recreate it, and apply all migrations:
 ```sh
 npm run db:reset
 ```
+
+## CLI Commands
+
+The RuneBingo API also provides CLI commands for managing the application.
+
+### Seeding the Database
+
+To seed the database with data, run the following command:
+
+```sh
+npm run db:seed
+```
+
+> [!CAUTION]
+> This command should only be run in development environments, as it will add/overwrite existing data and cannot be undone.
+
+This will add seeding data to the database from the `src/db/seeding/seeds/development` directory. You don't need to reset the database before seeding it, as it will automatically overwrite any existing data with the updated seed data.

--- a/api/nest-cli.json
+++ b/api/nest-cli.json
@@ -6,7 +6,8 @@
     "deleteOutDir": true,
     "assets": [
       { "include": "emailer/templates/html/*", "watchAssets": true },
-      { "include": "i18n/**/*", "watchAssets": true }
+      { "include": "i18n/**/*", "watchAssets": true },
+      { "include": "db/seeding/**/*.yml", "watchAssets": true }
     ]
   }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -23,7 +23,8 @@
     "db:migration:create": "npm run typeorm -- migration:create",
     "db:migration:generate": "npm run typeorm -- migration:generate -d ./src/db/index.ts",
     "db:migration:revert": "npm run typeorm migration:revert -- -d ./src/db/index.ts",
-    "db:reset": "npm run db:drop && npm run db:migrate"
+    "db:reset": "npm run db:drop && npm run db:migrate",
+    "db:seed": "cross-env NODE_ENV=development ts-node -r tsconfig-paths/register src/cli.ts seed"
   },
   "dependencies": {
     "@nestjs-modules/mailer": "^2.0.2",
@@ -44,7 +45,9 @@
     "dotenv": "^16.4.7",
     "express-session": "^1.18.1",
     "handlebars": "^4.7.8",
+    "joi": "^17.13.3",
     "lodash": "^4.17.21",
+    "nest-commander": "^3.17.0",
     "nestjs-i18n": "^10.5.0",
     "nodemailer": "^6.10.0",
     "pg": "^8.13.3",
@@ -54,7 +57,8 @@
     "swagger-themes": "^1.4.3",
     "typeorm": "^0.3.20",
     "typeorm-naming-strategies": "^4.1.0",
-    "ua-parser-js": "^2.0.2"
+    "ua-parser-js": "^2.0.2",
+    "yaml": "^2.7.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -6,6 +6,7 @@ import { AuthModule } from './auth/auth.module';
 import { configModule } from './config';
 import { cqrsModule } from './cqrs';
 import { dbModule } from './db';
+import { SeedingModule } from './db/seeding/seeding.module';
 import { EmailerModule } from './emailer/emailer.module';
 import { EmailerService } from './emailer/emailer.service';
 import { i18nModule } from './i18n';
@@ -23,6 +24,7 @@ import { UserModule } from './user/user.module';
     dbModule,
     i18nModule,
     RedisModule,
+    SeedingModule,
     SessionModule,
     UserModule,
     AuthModule,

--- a/api/src/cli.ts
+++ b/api/src/cli.ts
@@ -1,0 +1,12 @@
+import { CommandFactory } from 'nest-commander';
+
+import { CliModule } from './cli/cli.module';
+
+async function bootstrap() {
+  await CommandFactory.run(CliModule, {
+    logger: ['log', 'error', 'warn', 'debug'],
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+bootstrap();

--- a/api/src/cli/cli.module.ts
+++ b/api/src/cli/cli.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { CommandRunnerModule } from 'nest-commander';
+
+import { dbModule } from '@/db';
+import { SeedingModule } from '@/db/seeding/seeding.module';
+
+import { SeedCommand } from './seed.cli';
+import { configModule } from '../config';
+
+@Module({
+  imports: [CommandRunnerModule, configModule, dbModule, SeedingModule],
+  providers: [SeedCommand],
+})
+export class CliModule {}

--- a/api/src/cli/seed.cli.ts
+++ b/api/src/cli/seed.cli.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { Command, CommandRunner } from 'nest-commander';
+
+import { SeedingService } from '@/db/seeding/seeding.service';
+
+@Injectable()
+@Command({ name: 'seed', description: 'Runs the database seeding process' })
+export class SeedCommand extends CommandRunner {
+  constructor(private readonly seedingService: SeedingService) {
+    super();
+  }
+
+  async run() {
+    console.log('🌱 Running database seeding...');
+    await this.seedingService.initialize();
+    console.log('✅ Seeding completed!');
+  }
+}

--- a/api/src/db/seeding/development/user.yml
+++ b/api/src/db/seeding/development/user.yml
@@ -1,0 +1,27 @@
+char0o:
+  username: char0o
+  email: directfromquebec@gmail.com
+  emailVerified: true
+  role: admin
+  language: en
+
+raph:
+  username: Raph
+  email: raph.pion@gmail.com
+  emailVerified: true
+  role: admin
+  language: en
+
+zezima:
+  username: zezima
+  email: zezima@runebingo.com
+  emailVerified: true
+  role: moderator
+  language: en
+
+b0aty:
+  username: b0aty
+  email: b0aty@runebingo.com
+  emailVerified: true
+  role: user
+  language: en

--- a/api/src/db/seeding/seeder.ts
+++ b/api/src/db/seeding/seeder.ts
@@ -1,0 +1,93 @@
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+import { Logger } from '@nestjs/common';
+import { type ConfigService } from '@nestjs/config';
+import type Joi from 'joi';
+import { type ObjectLiteral, type DataSource, In, type FindOptionsWhere } from 'typeorm';
+import YAML from 'yaml';
+
+import { type AppConfig } from '../../config';
+
+export abstract class Seeder<Entity extends ObjectLiteral, Schema, Identifier = string> {
+  public abstract readonly entityName: string;
+
+  protected abstract readonly schema: Joi.Schema<Record<string, Schema>>;
+  protected abstract readonly identifierColumn: keyof Entity;
+  protected readonly entityMapping = new Map<string, Entity>();
+  protected readonly logger = new Logger(this.constructor.name);
+
+  constructor(
+    protected readonly configService: ConfigService<AppConfig>,
+    protected readonly db: DataSource,
+  ) {}
+
+  public async seed() {
+    const seeds = await this.getSeedData();
+    if (!seeds) {
+      return;
+    }
+
+    const identifierToKeyMap = new Map<Identifier, string>();
+    const repository = this.db.getRepository<Entity>(this.entityName);
+
+    const seedEntities = await Promise.all(
+      Object.entries(seeds).map(async ([key, seed]) => {
+        const entity = await this.deserialize(seed);
+        const identifier = await this.getIdentifier(entity);
+
+        identifierToKeyMap.set(identifier, key);
+        return entity;
+      }),
+    );
+
+    if (seedEntities.length === 0) return;
+
+    await repository.upsert(seedEntities, [this.identifierColumn as string]);
+
+    const identifiers = await Promise.all(seedEntities.map((e) => this.getIdentifier(e)));
+    const savedEntities = await repository.find({
+      where: { [this.identifierColumn]: In(identifiers) } as FindOptionsWhere<Entity>,
+    });
+
+    for (const entity of savedEntities) {
+      const identifier = await this.getIdentifier(entity);
+      if (!identifierToKeyMap.has(identifier)) continue;
+
+      this.entityMapping.set(identifierToKeyMap.get(identifier)!, entity);
+    }
+  }
+
+  public getEntity(key: string): Entity | null {
+    return this.entityMapping.get(key) || null;
+  }
+
+  protected abstract deserialize(seed: Schema): Entity | Promise<Entity>;
+
+  protected abstract getIdentifier(entity: Entity): Identifier | Promise<Identifier>;
+
+  private async getSeedData(): Promise<Record<string, Schema> | undefined> {
+    try {
+      const seedFileContents = await readFile(this.seedPath, 'utf-8');
+      const seedFileData = YAML.parse(seedFileContents) as Record<string, Schema>;
+      return this.schema.validateAsync(seedFileData);
+    } catch (e) {
+      this.logger.error(e);
+      return undefined;
+    }
+  }
+
+  private get seedPath() {
+    const env = this.configService.get('NODE_ENV', { infer: true });
+    const envDir = env ?? 'production';
+
+    // Convert the seeder class name to kebab-case
+    const seederName = this.constructor.name
+      .replace('Seeder', '')
+      .replace(/([a-z])([A-Z])/g, '$1-$2')
+      .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
+      .toLowerCase();
+
+    return join(__dirname, `./${envDir}/${seederName}.yml`);
+  }
+}

--- a/api/src/db/seeding/seeding.module.ts
+++ b/api/src/db/seeding/seeding.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { entities } from '..';
+import { SeedingService } from './seeding.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([...entities])],
+  providers: [SeedingService],
+  exports: [SeedingService],
+})
+export class SeedingModule {}

--- a/api/src/db/seeding/seeding.service.spec.ts
+++ b/api/src/db/seeding/seeding.service.spec.ts
@@ -1,0 +1,49 @@
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+import { Test, type TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import * as YAML from 'yaml';
+
+import { User } from '@/user/user.entity';
+
+import { dbModule, entities } from '..';
+import { SeedingService } from './seeding.service';
+import { configModule } from '../../config';
+
+describe('SeedingService', () => {
+  let module: TestingModule;
+  let seedingService: SeedingService;
+
+  const testSeedPath = join(__dirname, 'test');
+
+  const getSeedData = async (entity: string): Promise<object> => {
+    const path = join(testSeedPath, `${entity}.yml`);
+    const data = await readFile(path, 'utf-8');
+    return YAML.parse(data) as Record<string, object>;
+  };
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [configModule, dbModule, TypeOrmModule.forFeature(entities)],
+      providers: [SeedingService],
+    }).compile();
+
+    seedingService = module.get<SeedingService>(SeedingService);
+    await seedingService.initialize();
+  });
+
+  afterAll(async () => {
+    await seedingService.clear();
+    await module.close();
+  });
+
+  it.each([['user', User]])('seeds %s successfully', async (fileName, entityClass) => {
+    const seedData = await getSeedData(fileName);
+    for (const identifier of Object.keys(seedData)) {
+      const entity = seedingService.getEntity(entityClass, identifier);
+      expect(entity).not.toBeNull();
+      expect(entity).toBeInstanceOf(entityClass);
+    }
+  });
+});

--- a/api/src/db/seeding/seeding.service.ts
+++ b/api/src/db/seeding/seeding.service.ts
@@ -1,0 +1,62 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectDataSource } from '@nestjs/typeorm';
+import type { DataSource, EntityTarget, ObjectLiteral } from 'typeorm';
+
+import { entities } from '..';
+import { Seeder } from './seeder';
+import { UserSeeder } from './user.seeder';
+import { AppConfig } from '../../config';
+
+@Injectable()
+export class SeedingService {
+  private readonly logger = new Logger(SeedingService.name);
+
+  private readonly seedingEntityOrder = [
+    // Strong entities
+    UserSeeder,
+    // Weak entities
+    // Add more seeders here
+  ];
+
+  private readonly seederTypeMap = new Map<string, EntityTarget<ObjectLiteral>>(entities.map((e) => [e.name, e]));
+
+  private readonly seederMap = new Map<EntityTarget<ObjectLiteral>, Seeder<ObjectLiteral, unknown>>();
+
+  constructor(
+    @InjectDataSource() private readonly dataSource: DataSource,
+    private readonly configService: ConfigService<AppConfig>,
+  ) {}
+
+  public async initialize() {
+    for (const seeder of this.seedingEntityOrder) {
+      const instance = new seeder(this.configService, this.dataSource);
+      await instance.seed();
+
+      if (!this.seederTypeMap.has(instance.entityName)) {
+        this.logger.error(
+          `Seeder for entity ${instance.entityName} not found in 'seederTypeMap' but was present in 'seedingEntityOrder'.`,
+        );
+      }
+
+      this.seederMap.set(this.seederTypeMap.get(instance.entityName)!, instance);
+    }
+  }
+
+  public async clear() {
+    const env = this.configService.getOrThrow('NODE_ENV', { infer: true });
+    if (env !== 'development' && env !== 'test') {
+      throw new Error('Clearing the database is only allowed in development or test environments');
+    }
+
+    await this.dataSource.destroy();
+    this.seederMap.clear();
+  }
+
+  public getEntity<Entity extends ObjectLiteral>(entity: EntityTarget<Entity>, key: string): Entity | null {
+    const seeder = this.seederMap.get(entity);
+    if (!seeder) return null;
+
+    return seeder.getEntity(key) as Entity;
+  }
+}

--- a/api/src/db/seeding/test/user.yml
+++ b/api/src/db/seeding/test/user.yml
@@ -1,0 +1,27 @@
+char0o:
+  username: char0o
+  email: directfromquebec@gmail.com
+  emailVerified: true
+  role: admin
+  language: en
+
+raph:
+  username: Raph
+  email: raph.pion@gmail.com
+  emailVerified: true
+  role: admin
+  language: en
+
+zezima:
+  username: zezima
+  email: zezima@runebingo.com
+  emailVerified: true
+  role: moderator
+  language: en
+
+b0aty:
+  username: b0aty
+  email: b0aty@runebingo.com
+  emailVerified: true
+  role: user
+  language: en

--- a/api/src/db/seeding/user.seeder.ts
+++ b/api/src/db/seeding/user.seeder.ts
@@ -1,0 +1,55 @@
+import Joi from 'joi';
+
+import { Roles } from '@/auth/roles/roles.constants';
+import { User } from '@/user/user.entity';
+
+import { Seeder } from './seeder';
+
+type UserSeed = {
+  username: string;
+  email: string;
+  emailVerified: boolean;
+  role: Roles;
+  language: string;
+};
+
+const userSeedSchema = Joi.object<Record<string, UserSeed>>().pattern(
+  Joi.string(),
+  Joi.object({
+    username: Joi.string().required(),
+    email: Joi.string().email().required(),
+    emailVerified: Joi.boolean().required(),
+    role: Joi.string()
+      .valid(...Object.values(Roles))
+      .required(),
+    language: Joi.string().required(),
+  }),
+);
+
+export class UserSeeder extends Seeder<User, UserSeed> {
+  entityName = User.name;
+  identifierColumn = 'usernameNormalized' as keyof User;
+  schema = userSeedSchema;
+
+  protected deserialize(seed: UserSeed): User {
+    const emailNormalized = User.normalizeEmail(seed.email);
+    const usernameNormalized = User.normalizeUsername(seed.username);
+    const gravatarHash = User.generateGravatarHash(emailNormalized);
+
+    const user = new User();
+    user.username = seed.username;
+    user.usernameNormalized = usernameNormalized;
+    user.email = seed.email;
+    user.emailNormalized = emailNormalized;
+    user.emailVerified = seed.emailVerified;
+    user.role = seed.role;
+    user.language = seed.language;
+    user.gravatarHash = gravatarHash;
+
+    return user;
+  }
+
+  protected getIdentifier(entity: User): string {
+    return entity.usernameNormalized;
+  }
+}

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -23,6 +23,8 @@ async function bootstrap() {
     logger: new ConsoleLogger({ colors: true }),
   });
 
+  await app.init();
+
   const configService = app.get(ConfigService<AppConfig>);
   const port = configService.getOrThrow('server.port', { infer: true });
   const env = configService.get('NODE_ENV', { infer: true });

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,9 @@
         "dotenv": "^16.4.7",
         "express-session": "^1.18.1",
         "handlebars": "^4.7.8",
+        "joi": "^17.13.3",
         "lodash": "^4.17.21",
+        "nest-commander": "^3.17.0",
         "nestjs-i18n": "^10.5.0",
         "nodemailer": "^6.10.0",
         "pg": "^8.13.3",
@@ -41,7 +43,8 @@
         "swagger-themes": "^1.4.3",
         "typeorm": "^0.3.20",
         "typeorm-naming-strategies": "^4.1.0",
-        "ua-parser-js": "^2.0.2"
+        "ua-parser-js": "^2.0.2",
+        "yaml": "^2.7.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -237,7 +240,6 @@
       "version": "7.26.2",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
       "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.25.9",
@@ -399,7 +401,6 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
       "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1127,6 +1128,34 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@golevelup/nestjs-discovery": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@golevelup/nestjs-discovery/-/nestjs-discovery-4.0.3.tgz",
+      "integrity": "sha512-8w3CsXHN7+7Sn2i419Eal1Iw/kOjAd6Kb55M/ZqKBBwACCMn4WiEuzssC71LpBMI1090CiDxuelfPRwwIrQK+A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.x || ^11.0.0",
+        "@nestjs/core": "^10.x || ^11.0.0"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -3251,6 +3280,27 @@
         "url": "https://ko-fi.com/killymxi"
       }
     },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -3821,6 +3871,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/inquirer": {
+      "version": "8.2.10",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-8.2.10.tgz",
+      "integrity": "sha512-IdD5NmHyVjWM8SHWo/kPBgtzXatwPkfwzyP3fN1jF2g9BWt5WO+8hL2F4o2GKIYsU40PpqeevuUWvkS/roXJkA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/through": "*",
+        "rxjs": "^7.2.0"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -4013,6 +4074,16 @@
       "dependencies": {
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@types/through": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.33.tgz",
+      "integrity": "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/validator": {
@@ -4761,7 +4832,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.21.3"
@@ -5293,7 +5363,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -5305,7 +5374,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -5441,7 +5509,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5594,7 +5661,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5646,7 +5712,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -5683,7 +5748,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cheerio": {
@@ -5819,7 +5883,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^3.1.0"
@@ -5832,7 +5895,6 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5923,7 +5985,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -6175,7 +6236,6 @@
       "version": "8.3.6",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
       "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "import-fresh": "^3.3.0",
@@ -6937,7 +6997,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -7781,7 +7840,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chardet": "^0.7.0",
@@ -7796,7 +7854,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -7926,6 +7983,30 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -8781,7 +8862,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9051,7 +9131,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -9118,6 +9197,68 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/inquirer": {
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
+      "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.5.5",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6",
+        "wrap-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/inquirer/node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "license": "ISC"
+    },
+    "node_modules/inquirer/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/inspect-with-kind": {
       "version": "1.0.5",
@@ -9199,7 +9340,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-async-function": {
@@ -9460,7 +9600,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9658,7 +9797,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -10526,6 +10664,19 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "node_modules/js-beautify": {
       "version": "1.15.4",
       "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
@@ -10632,7 +10783,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -10671,7 +10821,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -10876,7 +11025,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/linkify-it": {
@@ -10982,7 +11130,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
@@ -11272,7 +11419,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -12012,6 +12158,45 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
     },
+    "node_modules/nest-commander": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/nest-commander/-/nest-commander-3.17.0.tgz",
+      "integrity": "sha512-1R9vppZT2j/9njKiG0zYTDLAyQOj14KdGWdNuhluveK8VXoQepXNb0t09dRNWy4KCWrI7wDZ2tQTEwb43JyHOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fig/complete-commander": "^3.0.0",
+        "@golevelup/nestjs-discovery": "4.0.3",
+        "commander": "11.1.0",
+        "cosmiconfig": "8.3.6",
+        "inquirer": "8.2.6"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@types/inquirer": "^8.1.3"
+      }
+    },
+    "node_modules/nest-commander/node_modules/@fig/complete-commander": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fig/complete-commander/-/complete-commander-3.2.0.tgz",
+      "integrity": "sha512-1Holl3XtRiANVKURZwgpjCnPuV4RsHp+XC0MhgvyAX/avQwj7F2HUItYOvGi/bXjJCkEzgBZmVfCr0HBA+q+Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "prettier": "^3.2.5"
+      },
+      "peerDependencies": {
+        "commander": "^11.1.0"
+      }
+    },
+    "node_modules/nest-commander/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/nestjs-i18n": {
       "version": "10.5.1",
       "resolved": "https://registry.npmjs.org/nestjs-i18n/-/nestjs-i18n-10.5.1.tgz",
@@ -12389,7 +12574,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -12440,7 +12624,6 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
       "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bl": "^4.1.0",
@@ -12464,7 +12647,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12474,7 +12656,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -12487,7 +12668,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12638,7 +12818,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -12651,7 +12830,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -12787,7 +12965,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12917,7 +13094,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -13095,7 +13271,6 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -13755,7 +13930,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -13801,7 +13975,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "onetime": "^5.1.0",
@@ -13815,7 +13988,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/reusify": {
@@ -13992,6 +14164,15 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/run-parallel": {
@@ -14989,7 +15170,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -15293,7 +15473,6 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -15327,7 +15506,6 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "os-tmpdir": "~1.0.2"
@@ -15606,7 +15784,6 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -16289,7 +16466,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
@@ -16299,7 +16475,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
       "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone": "^1.0.2"
@@ -16782,7 +16957,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -16836,7 +17010,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16846,7 +17019,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -16906,6 +17078,18 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",


### PR DESCRIPTION
<!-- Change XXXX for the issue number -->

[![Issue](https://img.shields.io/github/issues/detail/title/RuneBingo/RuneBingo/17?label=%2317&color=blue)](https://github.com/RuneBingo/RuneBingo/issues/17)

## Other relevant information

This task adds a new `SeedingService` to create entities from YAML files. It uses the current `NODE_ENV` to choose the folder from inside `api/src/db/seeding` and initialize or overwrite existing entities.

In development, you may now run:

```bash
npm run db:seed
```

This will seed the database. Neat! 🌱

## How to test

Make sure you have your test database initialized. Check your `.env` and remember your `POSTGRES_USER` and `POSTGRES_TEST_DB` values.

Then, check if the corresponding database exists and if not, create it, owner should be set to `POSTGRES_USER`.

## Test cases

- [ ] Run the `SeedingService` spec by running the following command from the `api` directory. The tests should pass successfully
  ```bash
  npx jest ./src/db/seeding/seeding.service.spec.ts
  ```

- [ ] Still in the `api` directory, run the following command, then check in your database that the seeding data has been created/overwritten:
  ```bash
  npm run db:seed
  ```