### PR TITLE
[Task] Make email configuration optional

### DIFF
--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -33,7 +33,7 @@ export type Configuration = {
     maxAge?: number;
   };
 
-  email: {
+  email?: {
     user: string;
     pass: string;
     name: string;

--- a/api/src/emailer/emailer.module.ts
+++ b/api/src/emailer/emailer.module.ts
@@ -16,7 +16,11 @@ import { type AppConfig } from '../config';
       imports: [ConfigModule],
       inject: [ConfigService, I18nService],
       useFactory: (configService: ConfigService<AppConfig>, i18n: I18nService) => {
-        const { user, pass, name } = configService.getOrThrow('email', { infer: true });
+        const emailConfig = configService.get('email', { infer: true });
+
+        const user = emailConfig?.user ?? '';
+        const pass = emailConfig?.pass ?? '';
+        const name = emailConfig?.name ?? '';
         const from = `"${name}" ${user}`;
 
         return {


### PR DESCRIPTION
[![Issue](https://img.shields.io/github/issues/detail/title/RuneBingo/RuneBingo/32?label=%2332&color=blue)](https://github.com/RuneBingo/RuneBingo/issues/32)

## Other relevant information

Little PR that makes the email configuration optional. This will avoid the need for frontend developers to have email credentials.

## How to test

- [ ] Run the app with the email configuration removed from the config files
- [ ] Try to send an email from the frontend (sign in, sign up) or using an API call

## Test cases

- [ ] No error is thrown when starting the app
- [ ] No error is thrown when trying to send an email
