### PR TITLE
[Feature] Organizers may manage the life cycle of their bingo event

### DIFF
--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -207,7 +207,7 @@ export class AuthController {
   @ApiOperation({ summary: 'Set the current bingo for the user' })
   @ApiNoContentResponse({ description: 'The current bingo has been set' })
   @ApiUnauthorizedResponse({ description: 'The user is not authenticated.' })
-  @ApiForbiddenResponse({ description: 'The user is not allowed to set this bingo as current because ' })
+  @ApiForbiddenResponse({ description: 'The user is not allowed to set this bingo as current.' })
   @HttpCode(HttpStatus.NO_CONTENT)
   @UseGuards(AuthGuard)
   async setCurrentBingo(@Request() req: Request, @Body() body: SetCurrentBingoDto) {

--- a/api/src/bingo/bingo.entity.ts
+++ b/api/src/bingo/bingo.entity.ts
@@ -65,7 +65,7 @@ export class Bingo extends StrongEntityParanoid {
 
   @ManyToOne(() => User, { nullable: true })
   @JoinColumn({ name: 'started_by' })
-  startedBy: Promise<User>;
+  startedBy: Promise<User | null>;
 
   @Column({ nullable: true, type: 'timestamptz' })
   endedAt: Date | null;
@@ -75,7 +75,7 @@ export class Bingo extends StrongEntityParanoid {
 
   @ManyToOne(() => User)
   @JoinColumn({ name: 'ended_by' })
-  endedBy: Promise<User>;
+  endedBy: Promise<User | null>;
 
   @Column({ nullable: true, type: 'timestamptz' })
   canceledAt: Date | null;
@@ -85,11 +85,21 @@ export class Bingo extends StrongEntityParanoid {
 
   @ManyToOne(() => User)
   @JoinColumn({ name: 'canceled_by' })
-  canceledBy: Promise<User>;
+  canceledBy: Promise<User | null>;
 
   @ManyToOne(() => User)
   @JoinColumn({ name: 'deleted_by' })
-  deletedBy: Promise<User>;
+  deletedBy: Promise<User | null>;
+
+  @Column({ nullable: true, type: 'timestamptz' })
+  resetAt: Date | null;
+
+  @Column({ name: 'reset_by', type: 'int', nullable: true })
+  resetById: number | null = null;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'reset_by' })
+  resetBy: Promise<User | null>;
 
   @Column({ type: 'date', nullable: true })
   maxRegistrationDate?: string;

--- a/api/src/bingo/bingo.module.ts
+++ b/api/src/bingo/bingo.module.ts
@@ -15,41 +15,54 @@ import { Bingo } from './bingo.entity';
 import { CancelBingoHandler } from './commands/cancel-bingo.command';
 import { CreateBingoHandler } from './commands/create-bingo.command';
 import { DeleteBingoHandler } from './commands/delete-bingo.command';
+import { EndBingoHandler } from './commands/end-bingo.command';
 import { FormatBingoActivitiesHandler } from './commands/format-bingo-activities.command';
+import { ResetBingoHandler } from './commands/reset-bingo.command';
+import { StartBingoHandler } from './commands/start-bingo.command';
 import { UpdateBingoHandler } from './commands/update-bingo.command';
 import { BingoCanceledHandler } from './events/bingo-canceled.event';
 import { BingoCreatedHandler } from './events/bingo-created.event';
 import { BingoDeletedHandler } from './events/bingo-deleted.event';
+import { BingoEndedHandler } from './events/bingo-ended.event';
+import { BingoResetHandler } from './events/bingo-reset.event';
+import { BingoStartedHandler } from './events/bingo-started.event';
 import { BingoUpdatedHandler } from './events/bingo-updated.event';
 import { FindBingoByBingoIdHandler } from './queries/find-bingo-by-bingo-id.query';
 import { SearchBingoActivitiesHandler } from './queries/search-bingo-activities.query';
 import { SearchBingosHandler } from './queries/search-bingos.query';
+import { BingoTile } from './tile/bingo-tile.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Bingo, User, Activity, BingoParticipant, BingoTeam])],
+  imports: [TypeOrmModule.forFeature([Bingo, User, Activity, BingoParticipant, BingoTeam, BingoTile])],
   controllers: [BingoController],
   providers: [
-    //Commands
-    CreateBingoHandler,
-    UpdateBingoHandler,
-    DeleteBingoHandler,
-    FormatBingoActivitiesHandler,
+    // Commands
     AddBingoParticipantHandler,
-    RemoveBingoParticipantHandler,
-    UpdateBingoParticipantHandler,
     CancelBingoHandler,
+    CreateBingoHandler,
+    DeleteBingoHandler,
+    EndBingoHandler,
+    FormatBingoActivitiesHandler,
+    RemoveBingoParticipantHandler,
+    ResetBingoHandler,
+    StartBingoHandler,
+    UpdateBingoHandler,
+    UpdateBingoParticipantHandler,
 
-    //Queries
+    // Queries
     FindBingoByBingoIdHandler,
-    SearchBingosHandler,
     SearchBingoActivitiesHandler,
     SearchBingoParticipantsHandler,
+    SearchBingosHandler,
 
-    //Events
-    BingoCreatedHandler,
-    BingoUpdatedHandler,
-    BingoDeletedHandler,
+    // Events
     BingoCanceledHandler,
+    BingoCreatedHandler,
+    BingoDeletedHandler,
+    BingoEndedHandler,
+    BingoResetHandler,
+    BingoStartedHandler,
+    BingoUpdatedHandler,
   ],
 })
 export class BingoModule {}

--- a/api/src/bingo/commands/cancel-bingo.command.spec.ts
+++ b/api/src/bingo/commands/cancel-bingo.command.spec.ts
@@ -65,8 +65,8 @@ describe('CancelBingoHandler', () => {
     await expect(handler.execute(command)).rejects.toThrow(ForbiddenException);
   });
 
-  it('throws ForbiddenException if the requester is a bingo participant without organizer role', async () => {
-    const requester = seedingService.getEntity(User, 'dee420');
+  it('throws ForbiddenException if the requester is a bingo participant without owner role', async () => {
+    const requester = seedingService.getEntity(User, 'didiking');
     const bingo = seedingService.getEntity(Bingo, 'osrs-qc');
 
     const command = new CancelBingoCommand({
@@ -89,8 +89,8 @@ describe('CancelBingoHandler', () => {
     await expect(handler.execute(command)).rejects.toThrow(BadRequestException);
   });
 
-  it('cancels the bingo if user is at least organizer and emits BingoCanceledEvent', async () => {
-    const requester = seedingService.getEntity(User, 'didiking');
+  it('cancels the bingo if user is owner and emits BingoCanceledEvent', async () => {
+    const requester = seedingService.getEntity(User, 'char0o');
     const bingo = seedingService.getEntity(Bingo, 'osrs-qc');
 
     const command = new CancelBingoCommand({
@@ -127,7 +127,7 @@ describe('CancelBingoHandler', () => {
     expect(canceledBingo.canceledById).toBe(requester.id);
   });
 
-  it('throws NotFound if the bingo doesnt exist', async () => {
+  it("throws NotFound if the bingo doesn't exist", async () => {
     const requester = seedingService.getEntity(User, 'dee420');
 
     const command = new CancelBingoCommand({

--- a/api/src/bingo/commands/cancel-bingo.command.ts
+++ b/api/src/bingo/commands/cancel-bingo.command.ts
@@ -54,7 +54,7 @@ export class CancelBingoHandler {
       userId: requester.id,
     });
 
-    if (!new BingoPolicies(requester).canCancel(bingoParticipant, bingo)) {
+    if (!new BingoPolicies(requester, bingoParticipant).canCancel()) {
       throw new ForbiddenException(this.i18nService.t('bingo.cancelBingo.forbidden'));
     }
 

--- a/api/src/bingo/commands/delete-bingo.command.spec.ts
+++ b/api/src/bingo/commands/delete-bingo.command.spec.ts
@@ -112,10 +112,15 @@ describe('DeleteBingoHandler', () => {
       bingoId: bingo.bingoId,
     });
 
-    const toDelete = await handler.execute(command);
-    expect(toDelete).toBeDefined();
-    expect(toDelete.deletedAt).toBeDefined();
-    expect(toDelete.deletedById).toBe(requester.id);
+    await handler.execute(command);
+
+    const deletedBingo = await dataSource
+      .getRepository(Bingo)
+      .findOne({ where: { bingoId: bingo.bingoId }, withDeleted: true });
+
+    expect(deletedBingo).toBeDefined();
+    expect(deletedBingo?.deletedAt).toBeDefined();
+    expect(deletedBingo?.deletedById).toBe(requester.id);
 
     const updatedBingoParticipants = await dataSource.getRepository(BingoParticipant).find({
       where: {
@@ -127,7 +132,7 @@ describe('DeleteBingoHandler', () => {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(eventBus.publish).toHaveBeenCalledWith(
       new BingoDeletedEvent({
-        bingoId: toDelete.id,
+        bingoId: bingo.id,
         requesterId: requester.id,
       }),
     );
@@ -142,9 +147,14 @@ describe('DeleteBingoHandler', () => {
       bingoId: bingo.bingoId,
     });
 
-    const toDelete = await handler.execute(command);
-    expect(toDelete).toBeDefined();
-    expect(toDelete.deletedAt).toBeDefined();
-    expect(toDelete.deletedById).toBe(requester.id);
+    await handler.execute(command);
+
+    const deletedBingo = await dataSource
+      .getRepository(Bingo)
+      .findOne({ where: { bingoId: bingo.bingoId }, withDeleted: true });
+
+    expect(deletedBingo).toBeDefined();
+    expect(deletedBingo?.deletedAt).toBeDefined();
+    expect(deletedBingo?.deletedById).toBe(requester.id);
   });
 });

--- a/api/src/bingo/commands/end-bingo.command.spec.ts
+++ b/api/src/bingo/commands/end-bingo.command.spec.ts
@@ -1,0 +1,127 @@
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { EventBus } from '@nestjs/cqrs';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { format } from 'date-fns';
+import { DataSource } from 'typeorm';
+
+import { configModule } from '@/config';
+import { dbModule } from '@/db';
+import { SeedingService } from '@/db/seeding/seeding.service';
+import { i18nModule } from '@/i18n';
+import { User } from '@/user/user.entity';
+
+import { EndBingoCommand, EndBingoHandler } from './end-bingo.command';
+import { BingoStatus } from '../bingo-status.enum';
+import { Bingo } from '../bingo.entity';
+import { BingoEndedEvent } from '../events/bingo-ended.event';
+import { BingoParticipant } from '../participant/bingo-participant.entity';
+import { BingoTile } from '../tile/bingo-tile.entity';
+
+describe('EndBingoHandler', () => {
+  let module: TestingModule;
+  let seedingService: SeedingService;
+  let eventBus: jest.Mocked<EventBus>;
+  let handler: EndBingoHandler;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        configModule,
+        dbModule,
+        i18nModule,
+        TypeOrmModule.forFeature([Bingo, BingoParticipant, BingoTile, User]),
+      ],
+      providers: [
+        EndBingoHandler,
+        SeedingService,
+        {
+          provide: EventBus,
+          useValue: {
+            publish: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    handler = module.get(EndBingoHandler);
+    eventBus = module.get(EventBus);
+    seedingService = module.get(SeedingService);
+    dataSource = module.get(DataSource);
+  });
+
+  beforeEach(async () => {
+    await seedingService.initialize();
+  });
+
+  afterEach(async () => {
+    await seedingService.clear();
+  });
+
+  afterAll(() => {
+    return module.close();
+  });
+
+  it('throws NotFoundException if the requester is not allowed to see the bingo', async () => {
+    const requester = seedingService.getEntity(User, 'b0aty');
+    const bingo = seedingService.getEntity(Bingo, 'osrs-qc');
+
+    const command = new EndBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+    });
+
+    await expect(handler.execute(command)).rejects.toThrow(NotFoundException);
+  });
+
+  it('throws ForbiddenException if the requester is not a participant or a moderator', async () => {
+    const requester = seedingService.getEntity(User, 'b0aty');
+    const bingo = seedingService.getEntity(Bingo, 'started-bingo');
+
+    const command = new EndBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+    });
+
+    await expect(handler.execute(command)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('throws BadRequestException if the bingo is not ongoing', async () => {
+    const requester = seedingService.getEntity(User, 'raph');
+    const bingo = seedingService.getEntity(Bingo, 'ready_bingo');
+
+    const command = new EndBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+    });
+
+    await expect(handler.execute(command)).rejects.toThrow(BadRequestException);
+  });
+
+  it('ends the bingo and emits a BingoEndedEvent', async () => {
+    const requester = seedingService.getEntity(User, 'didiking');
+    const bingo = seedingService.getEntity(Bingo, 'started-bingo');
+
+    const endDate = format(new Date(), 'yyyy-MM-dd');
+
+    const command = new EndBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+    });
+
+    const startedBingo = await handler.execute(command);
+    expect(startedBingo).toBeDefined();
+    expect(startedBingo.status).toBe(BingoStatus.Completed);
+    expect(startedBingo.endDate).toBe(endDate);
+    expect(startedBingo.endedAt).toBeDefined();
+    expect(startedBingo.endedById).toBe(requester.id);
+    await expect(startedBingo.updatedBy).resolves.toBe(requester);
+    await expect(startedBingo.endedBy).resolves.toBe(requester);
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(eventBus.publish).toHaveBeenCalledWith(
+      new BingoEndedEvent({ bingoId: bingo.id, requesterId: requester.id, early: true }),
+    );
+  });
+});

--- a/api/src/bingo/commands/end-bingo.command.ts
+++ b/api/src/bingo/commands/end-bingo.command.ts
@@ -1,0 +1,88 @@
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Command, CommandHandler, EventBus } from '@nestjs/cqrs';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { format } from 'date-fns';
+import { I18nService } from 'nestjs-i18n';
+import { DataSource, Repository } from 'typeorm';
+
+import { I18nTranslations } from '@/i18n/types';
+import { User } from '@/user/user.entity';
+
+import { BingoStatus } from '../bingo-status.enum';
+import { Bingo } from '../bingo.entity';
+import { BingoPolicies } from '../bingo.policies';
+import { BingoEndedEvent } from '../events/bingo-ended.event';
+import { BingoParticipant } from '../participant/bingo-participant.entity';
+import { ViewBingoScope } from '../scopes/view-bingo.scope';
+
+export type EndBingoParams = {
+  requester: User;
+  bingoId: string;
+};
+
+export type EndBingoResult = Bingo;
+
+export class EndBingoCommand extends Command<EndBingoResult> {
+  constructor(public readonly params: EndBingoParams) {
+    super();
+    this.params = params;
+  }
+}
+
+@CommandHandler(EndBingoCommand)
+export class EndBingoHandler {
+  constructor(
+    private readonly eventBus: EventBus,
+    private readonly i18nService: I18nService<I18nTranslations>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+    @InjectRepository(Bingo)
+    private readonly bingoRepository: Repository<Bingo>,
+    @InjectRepository(BingoParticipant)
+    private readonly bingoParticipantRepository: Repository<BingoParticipant>,
+  ) {}
+
+  async execute(command: EndBingoCommand): Promise<EndBingoResult> {
+    const { requester, bingoId } = command.params;
+
+    let scope = this.bingoRepository.createQueryBuilder('bingo').where('bingo.bingoId = :bingoId', { bingoId });
+    scope = new ViewBingoScope(requester, scope).resolve();
+
+    const bingo = await scope.getOne();
+    if (!bingo) {
+      throw new NotFoundException(this.i18nService.t('bingo.endBingo.bingoNotFound'));
+    }
+
+    const bingoParticipant = await this.bingoParticipantRepository.findOneBy({
+      bingoId: bingo.id,
+      userId: requester.id,
+    });
+
+    if (!new BingoPolicies(requester, bingoParticipant).canEnd()) {
+      throw new ForbiddenException(this.i18nService.t('bingo.endBingo.forbidden'));
+    }
+
+    if (bingo.status !== BingoStatus.Ongoing) {
+      throw new BadRequestException(this.i18nService.t('bingo.endBingo.notOngoing'));
+    }
+
+    await this.dataSource.transaction(async (entityManager) => {
+      // TODO: cancel all pending tile completion requests
+      // TODO: recompute all scores
+
+      bingo.updatedById = requester.id;
+      bingo.updatedBy = Promise.resolve(requester);
+
+      bingo.endDate = format(new Date(), 'yyyy-MM-dd');
+      bingo.endedAt = new Date();
+      bingo.endedById = requester.id;
+      bingo.endedBy = Promise.resolve(requester);
+
+      await entityManager.save(bingo);
+    });
+
+    this.eventBus.publish(new BingoEndedEvent({ bingoId: bingo.id, requesterId: requester.id, early: true }));
+
+    return bingo;
+  }
+}

--- a/api/src/bingo/commands/format-bingo-activities.command.ts
+++ b/api/src/bingo/commands/format-bingo-activities.command.ts
@@ -38,12 +38,18 @@ export class FormatBingoActivitiesHandler {
         switch (activity.key) {
           case 'bingo.created':
             return this.formatBingoCreatedActivity(activity);
-          case 'bingo.updated':
-            return this.formatBingoUpdatedActivity(activity);
           case 'bingo.canceled':
             return this.formatBingoCanceledActivity(activity);
           case 'bingo.deleted':
             return this.formatBingoDeletedActivity(activity);
+          case 'bingo.started':
+            return this.formatBingoStartedActivity(activity);
+          case 'bingo.ended':
+            return this.formatBingoEndedActivity(activity);
+          case 'bingo.updated':
+            return this.formatBingoUpdatedActivity(activity);
+          case 'bingo.reset':
+            return this.formatBingoResetActivity(activity);
           case 'bingo.participant.added':
             return this.formatBingoParticipantAddedActivity(activity);
           case 'bingo.participant.removed':
@@ -56,9 +62,6 @@ export class FormatBingoActivitiesHandler {
             return this.formatBingoTileDeletedActivity(activity);
           case 'bingo.tile.moved':
             return this.formatBingoTileMovedActivity(activity);
-          default:
-            this.logger.error(`Unsupported activity key: ${activity.key}`);
-            return null;
         }
       }),
     );
@@ -116,8 +119,48 @@ export class FormatBingoActivitiesHandler {
         case 'endDate':
           body.push(this.i18nService.t('bingo.activity.updated.body.endDate', { args: { endDate: value } }));
           break;
-        default:
-          this.logger.error(`Unsupported activity parameter for 'bingo.update': ${key}`);
+      }
+    });
+
+    return new ActivityDto(requester ?? null, activity.createdAt, activity.key, title, body);
+  }
+
+  private formatBingoResetActivity(activity: Activity): ActivityDto {
+    const requester = activity.createdById ? this.usersMap.get(activity.createdById) : null;
+    const requesterName = requester?.username ?? this.i18nService.t('general.system');
+    const title = this.i18nService.t('bingo.activity.reset.title', {
+      args: { username: requesterName },
+    });
+
+    const body: string[] = [];
+
+    Object.entries(activity.parameters ?? {}).forEach(([key, value]) => {
+      switch (key) {
+        case 'startDate':
+          body.push(this.i18nService.t('bingo.activity.reset.body.startDate', { args: { startDate: value } }));
+          break;
+        case 'endDate':
+          body.push(this.i18nService.t('bingo.activity.reset.body.endDate', { args: { endDate: value } }));
+          break;
+        case 'maxRegistrationDate':
+          body.push(
+            this.i18nService.t('bingo.activity.reset.body.maxRegistrationDate', {
+              args: { maxRegistrationDate: value },
+            }),
+          );
+          break;
+        case 'deletedTiles':
+          body.push(this.i18nService.t('bingo.activity.reset.body.deletedTiles', { args: { deletedTiles: value } }));
+          break;
+        case 'deletedTeams':
+          body.push(this.i18nService.t('bingo.activity.reset.body.deletedTeams', { args: { deletedTeams: value } }));
+          break;
+        case 'deletedParticipants':
+          body.push(
+            this.i18nService.t('bingo.activity.reset.body.deletedParticipants', {
+              args: { deletedParticipants: value },
+            }),
+          );
           break;
       }
     });
@@ -129,6 +172,38 @@ export class FormatBingoActivitiesHandler {
     const requester = activity.createdById ? this.usersMap.get(activity.createdById) : null;
     const requesterName = requester?.username ?? this.i18nService.t('general.system');
     const title = this.i18nService.t('bingo.activity.deleted.title', {
+      args: { username: requesterName },
+    });
+
+    return new ActivityDto(requester ?? null, activity.createdAt, activity.key, title);
+  }
+
+  private formatBingoStartedActivity(activity: Activity): ActivityDto {
+    const requester = activity.createdById ? this.usersMap.get(activity.createdById) : null;
+    const requesterName = requester?.username ?? this.i18nService.t('general.system');
+    const titleKey = activity.parameters?.early ? 'titleEarly' : 'title';
+    const title = this.i18nService.t(`bingo.activity.started.${titleKey}`, {
+      args: { username: requesterName },
+    });
+
+    const body: string[] = [];
+
+    Object.entries(activity.parameters ?? {}).forEach(([key, value]) => {
+      switch (key) {
+        case 'endDate':
+          body.push(this.i18nService.t('bingo.activity.started.body.endDate', { args: { endDate: value } }));
+          break;
+      }
+    });
+
+    return new ActivityDto(requester ?? null, activity.createdAt, activity.key, title, body);
+  }
+
+  private formatBingoEndedActivity(activity: Activity): ActivityDto {
+    const requester = activity.createdById ? this.usersMap.get(activity.createdById) : null;
+    const requesterName = requester?.username ?? this.i18nService.t('general.system');
+    const titleKey = activity.parameters?.early ? 'titleEarly' : 'title';
+    const title = this.i18nService.t(`bingo.activity.ended.${titleKey}`, {
       args: { username: requesterName },
     });
 
@@ -199,9 +274,6 @@ export class FormatBingoActivitiesHandler {
             }),
           );
           break;
-        default:
-          this.logger.error(`Unsupported activity parameter for 'bingo.update': ${key}`);
-          break;
       }
     });
 
@@ -249,8 +321,6 @@ export class FormatBingoActivitiesHandler {
           break;
         case 'items':
           body.push(this.i18nService.t('bingo.tile.activity.set.body.items'));
-          break;
-        default:
           break;
       }
     });

--- a/api/src/bingo/commands/reset-bingo.command.spec.ts
+++ b/api/src/bingo/commands/reset-bingo.command.spec.ts
@@ -1,0 +1,294 @@
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { EventBus } from '@nestjs/cqrs';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { addDays, formatDate, subDays } from 'date-fns';
+import { DataSource } from 'typeorm';
+
+import { configModule } from '@/config';
+import { dbModule } from '@/db';
+import { SeedingService } from '@/db/seeding/seeding.service';
+import { i18nModule } from '@/i18n';
+import { User } from '@/user/user.entity';
+
+import { ResetBingoCommand, ResetBingoHandler } from './reset-bingo.command';
+import { BingoStatus } from '../bingo-status.enum';
+import { Bingo } from '../bingo.entity';
+import { BingoResetEvent } from '../events/bingo-reset.event';
+import { BingoParticipant } from '../participant/bingo-participant.entity';
+import { BingoTeam } from '../team/bingo-team.entity';
+import { BingoTileItem } from '../tile/bingo-tile-item';
+import { BingoTile } from '../tile/bingo-tile.entity';
+
+describe('ResetBingoHandler', () => {
+  let module: TestingModule;
+  let seedingService: SeedingService;
+  let eventBus: jest.Mocked<EventBus>;
+  let handler: ResetBingoHandler;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        configModule,
+        dbModule,
+        i18nModule,
+        TypeOrmModule.forFeature([Bingo, BingoTile, BingoTileItem, BingoTeam, BingoParticipant, User]),
+      ],
+      providers: [
+        ResetBingoHandler,
+        SeedingService,
+        {
+          provide: EventBus,
+          useValue: {
+            publish: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    handler = module.get(ResetBingoHandler);
+    eventBus = module.get(EventBus);
+    seedingService = module.get(SeedingService);
+    dataSource = module.get(DataSource);
+  });
+
+  beforeEach(async () => {
+    await seedingService.initialize();
+  });
+
+  afterEach(async () => {
+    await seedingService.clear();
+  });
+
+  afterAll(() => {
+    return module.close();
+  });
+
+  it('throws NotFoundException if the requester is not allowed to see the bingo', async () => {
+    const requester = seedingService.getEntity(User, 'b0aty');
+    const bingo = seedingService.getEntity(Bingo, 'lifecycle-bingo');
+
+    const command = new ResetBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+      startDate: formatDate(addDays(new Date(), 2), 'yyyy-MM-dd'),
+      endDate: formatDate(addDays(new Date(), 3), 'yyyy-MM-dd'),
+      maxRegistrationDate: formatDate(addDays(new Date(), 1), 'yyyy-MM-dd'),
+    });
+
+    await expect(handler.execute(command)).rejects.toThrow(NotFoundException);
+  });
+
+  it('throws ForbiddenException if the requester is not allowed to reset the bingo', async () => {
+    const requester = seedingService.getEntity(User, 'didiking');
+    const bingo = seedingService.getEntity(Bingo, 'lifecycle-bingo');
+
+    const command = new ResetBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+      startDate: formatDate(addDays(new Date(), 2), 'yyyy-MM-dd'),
+      endDate: formatDate(addDays(new Date(), 3), 'yyyy-MM-dd'),
+      maxRegistrationDate: formatDate(addDays(new Date(), 1), 'yyyy-MM-dd'),
+    });
+
+    await expect(handler.execute(command)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('throws BadRequestException if the bingo is not canceled', async () => {
+    const requester = seedingService.getEntity(User, 'raph');
+    const bingo = seedingService.getEntity(Bingo, 'ready_bingo');
+
+    const command = new ResetBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+      startDate: formatDate(addDays(new Date(), 2), 'yyyy-MM-dd'),
+      endDate: formatDate(addDays(new Date(), 3), 'yyyy-MM-dd'),
+      maxRegistrationDate: formatDate(addDays(new Date(), 1), 'yyyy-MM-dd'),
+    });
+
+    await expect(handler.execute(command)).rejects.toThrow(BadRequestException);
+  });
+
+  it('throws BadRequestException if the start date is before today', async () => {
+    const requester = seedingService.getEntity(User, 'raph');
+    const bingo = seedingService.getEntity(Bingo, 'lifecycle-bingo');
+
+    const command = new ResetBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+      startDate: formatDate(subDays(new Date(), 1), 'yyyy-MM-dd'),
+      endDate: formatDate(addDays(new Date(), 3), 'yyyy-MM-dd'),
+      maxRegistrationDate: formatDate(addDays(new Date(), 1), 'yyyy-MM-dd'),
+    });
+
+    await expect(handler.execute(command)).rejects.toThrow(BadRequestException);
+  });
+
+  it('throws BadRequestException if the start date is before the max registration date', async () => {
+    const requester = seedingService.getEntity(User, 'raph');
+    const bingo = seedingService.getEntity(Bingo, 'lifecycle-bingo');
+
+    const command = new ResetBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+      startDate: formatDate(addDays(new Date(), 1), 'yyyy-MM-dd'),
+      endDate: formatDate(addDays(new Date(), 3), 'yyyy-MM-dd'),
+      maxRegistrationDate: formatDate(addDays(new Date(), 2), 'yyyy-MM-dd'),
+    });
+
+    await expect(handler.execute(command)).rejects.toThrow(BadRequestException);
+  });
+
+  it('throws BadRequestException if the end date is before the start date', async () => {
+    const requester = seedingService.getEntity(User, 'raph');
+    const bingo = seedingService.getEntity(Bingo, 'lifecycle-bingo');
+
+    const command = new ResetBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+      startDate: formatDate(addDays(new Date(), 3), 'yyyy-MM-dd'),
+      endDate: formatDate(addDays(new Date(), 2), 'yyyy-MM-dd'),
+      maxRegistrationDate: formatDate(subDays(new Date(), 2), 'yyyy-MM-dd'),
+    });
+
+    await expect(handler.execute(command)).rejects.toThrow(BadRequestException);
+  });
+
+  it('resets the bingo and its lifecycle and emits a BingoResetEvent', async () => {
+    const requester = seedingService.getEntity(User, 'raph');
+    const bingo = seedingService.getEntity(Bingo, 'lifecycle-bingo');
+
+    const tilesCount = await dataSource.manager.count(BingoTile, { where: { bingoId: bingo.id } });
+    const teamsCount = await dataSource.manager.count(BingoTeam, { where: { bingoId: bingo.id } });
+    const participantsCount = await dataSource.manager.count(BingoParticipant, { where: { bingoId: bingo.id } });
+
+    const command = new ResetBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+      startDate: formatDate(addDays(new Date(), 1), 'yyyy-MM-dd'),
+      endDate: formatDate(addDays(new Date(), 3), 'yyyy-MM-dd'),
+      maxRegistrationDate: formatDate(addDays(new Date(), 1), 'yyyy-MM-dd'),
+    });
+
+    const result = await handler.execute(command);
+
+    const newTilesCount = await dataSource.manager.count(BingoTile, { where: { bingoId: bingo.id } });
+    const newTeamsCount = await dataSource.manager.count(BingoTeam, { where: { bingoId: bingo.id } });
+    const newParticipantsCount = await dataSource.manager.count(BingoParticipant, { where: { bingoId: bingo.id } });
+
+    expect(result.status).toBe(BingoStatus.Pending);
+    expect(result.startDate).toBe(formatDate(addDays(new Date(), 1), 'yyyy-MM-dd'));
+    expect(result.endDate).toBe(formatDate(addDays(new Date(), 3), 'yyyy-MM-dd'));
+    expect(result.maxRegistrationDate).toBe(formatDate(addDays(new Date(), 1), 'yyyy-MM-dd'));
+    expect(result.canceledAt).toBeNull();
+    expect(result.startedAt).toBeNull();
+    expect(result.endedAt).toBeNull();
+    expect(result.canceledById).toBeNull();
+    expect(result.startedById).toBeNull();
+    expect(result.endedById).toBeNull();
+    expect(result.resetById).toEqual(requester.id);
+    expect(result.resetAt).toBeInstanceOf(Date);
+
+    await expect(result.startedBy).resolves.toBeNull();
+    await expect(result.endedBy).resolves.toBeNull();
+    await expect(result.canceledBy).resolves.toBeNull();
+    await expect(result.resetBy).resolves.toEqual(requester);
+
+    expect(newTilesCount).toBe(tilesCount);
+    expect(newTeamsCount).toBe(teamsCount);
+    expect(newParticipantsCount).toBe(participantsCount);
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    void expect(eventBus.publish).toHaveBeenCalledWith(
+      new BingoResetEvent({
+        bingoId: bingo.id,
+        requesterId: requester.id,
+        deletedTiles: false,
+        deletedTeams: false,
+        deletedParticipants: false,
+        startDate: formatDate(addDays(new Date(), 1), 'yyyy-MM-dd'),
+        endDate: formatDate(addDays(new Date(), 3), 'yyyy-MM-dd'),
+        maxRegistrationDate: formatDate(addDays(new Date(), 1), 'yyyy-MM-dd'),
+      }),
+    );
+  });
+
+  it('deletes all the tiles if deleteTiles is true', async () => {
+    const requester = seedingService.getEntity(User, 'raph');
+    const bingo = seedingService.getEntity(Bingo, 'lifecycle-bingo');
+
+    const command = new ResetBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+      startDate: formatDate(addDays(new Date(), 1), 'yyyy-MM-dd'),
+      endDate: formatDate(addDays(new Date(), 3), 'yyyy-MM-dd'),
+      maxRegistrationDate: formatDate(addDays(new Date(), 1), 'yyyy-MM-dd'),
+      deleteTiles: true,
+    });
+
+    await handler.execute(command);
+
+    const newTilesCount = await dataSource.manager.count(BingoTile, { where: { bingoId: bingo.id } });
+    expect(newTilesCount).toBe(0);
+  });
+
+  it('resets the teams points if deleteTeams is false', async () => {
+    const requester = seedingService.getEntity(User, 'raph');
+    const bingo = seedingService.getEntity(Bingo, 'lifecycle-bingo');
+
+    const command = new ResetBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+      startDate: formatDate(addDays(new Date(), 1), 'yyyy-MM-dd'),
+      endDate: formatDate(addDays(new Date(), 3), 'yyyy-MM-dd'),
+      maxRegistrationDate: formatDate(addDays(new Date(), 1), 'yyyy-MM-dd'),
+    });
+
+    await handler.execute(command);
+
+    const teams = await dataSource.manager.find(BingoTeam, { where: { bingoId: bingo.id } });
+    const teamsPoints = teams.reduce((acc, team) => acc + team.points, 0);
+    expect(teamsPoints).toBe(0);
+  });
+
+  it('deletes all the participants if deleteParticipants is true', async () => {
+    const requester = seedingService.getEntity(User, 'raph');
+    const bingo = seedingService.getEntity(Bingo, 'lifecycle-bingo');
+
+    const command = new ResetBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+      startDate: formatDate(addDays(new Date(), 1), 'yyyy-MM-dd'),
+      endDate: formatDate(addDays(new Date(), 3), 'yyyy-MM-dd'),
+      maxRegistrationDate: formatDate(addDays(new Date(), 1), 'yyyy-MM-dd'),
+      deleteParticipants: true,
+    });
+
+    await handler.execute(command);
+
+    const newParticipantsCount = await dataSource.manager.count(BingoParticipant, { where: { bingoId: bingo.id } });
+    expect(newParticipantsCount).toBe(0);
+  });
+
+  it('removes the team captains if deleteParticipants is true but deleteTeams is false', async () => {
+    const requester = seedingService.getEntity(User, 'raph');
+    const bingo = seedingService.getEntity(Bingo, 'lifecycle-bingo');
+
+    const command = new ResetBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+      startDate: formatDate(addDays(new Date(), 1), 'yyyy-MM-dd'),
+      endDate: formatDate(addDays(new Date(), 3), 'yyyy-MM-dd'),
+      maxRegistrationDate: formatDate(addDays(new Date(), 1), 'yyyy-MM-dd'),
+      deleteParticipants: true,
+    });
+
+    await handler.execute(command);
+
+    const teams = await dataSource.manager.find(BingoTeam, { where: { bingoId: bingo.id } });
+    teams.forEach((team) => {
+      expect(team.captainId).toBeNull();
+    });
+  });
+});

--- a/api/src/bingo/commands/reset-bingo.command.ts
+++ b/api/src/bingo/commands/reset-bingo.command.ts
@@ -1,0 +1,189 @@
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Command, CommandHandler, EventBus } from '@nestjs/cqrs';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { format, isBefore } from 'date-fns';
+import { I18nService } from 'nestjs-i18n';
+import { DataSource, EntityManager, In, Repository } from 'typeorm';
+
+import { I18nTranslations } from '@/i18n/types';
+import { User } from '@/user/user.entity';
+
+import { BingoStatus } from '../bingo-status.enum';
+import { Bingo } from '../bingo.entity';
+import { BingoPolicies } from '../bingo.policies';
+import { BingoResetEvent } from '../events/bingo-reset.event';
+import { BingoParticipant } from '../participant/bingo-participant.entity';
+import { ViewBingoScope } from '../scopes/view-bingo.scope';
+import { BingoTeam } from '../team/bingo-team.entity';
+import { BingoTileItem } from '../tile/bingo-tile-item';
+import { BingoTile } from '../tile/bingo-tile.entity';
+
+export type ResetBingoParams = {
+  requester: User;
+  bingoId: string;
+  startDate: string;
+  endDate: string;
+  maxRegistrationDate: string;
+  deleteTiles?: boolean;
+  deleteTeams?: boolean;
+  deleteParticipants?: boolean;
+};
+
+export type ResetBingoResult = Bingo;
+
+export class ResetBingoCommand extends Command<ResetBingoResult> {
+  constructor(public readonly params: ResetBingoParams) {
+    super();
+    this.params = params;
+  }
+}
+
+@CommandHandler(ResetBingoCommand)
+export class ResetBingoHandler {
+  constructor(
+    private readonly eventBus: EventBus,
+    private readonly i18n: I18nService<I18nTranslations>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+    @InjectRepository(BingoParticipant)
+    private readonly bingoParticipantRepository: Repository<BingoParticipant>,
+  ) {}
+
+  async execute(command: ResetBingoCommand): Promise<ResetBingoResult> {
+    const {
+      requester,
+      bingoId,
+      startDate,
+      endDate,
+      maxRegistrationDate,
+      deleteTiles = false,
+      deleteTeams = false,
+      deleteParticipants = false,
+    } = command.params;
+
+    const bingo = await this.fetchBingo(requester, bingoId);
+    await this.authorize(requester, bingo);
+
+    if (bingo.status !== BingoStatus.Canceled) {
+      throw new BadRequestException(this.i18n.t('bingo.resetBingo.notCanceled'));
+    }
+
+    this.validateDates(startDate, endDate, maxRegistrationDate);
+
+    await this.dataSource.transaction(async (manager) => {
+      // TODO: delete tile completion requests
+      if (deleteTiles) await this.deleteTiles(manager, bingo);
+
+      if (deleteTeams) {
+        await manager.softRemove(BingoTeam, { bingoId: bingo.id });
+      } else {
+        await manager.update(BingoTeam, { bingoId: bingo.id }, { points: 0 });
+      }
+
+      if (deleteParticipants) await this.deleteParticipants(manager, bingo, deleteTeams);
+
+      this.resetBingoLifecycle(requester, bingo, startDate, endDate, maxRegistrationDate);
+
+      await manager.save(bingo);
+    });
+
+    await this.eventBus.publish(
+      new BingoResetEvent({
+        bingoId: bingo.id,
+        requesterId: requester.id,
+        startDate,
+        endDate,
+        maxRegistrationDate,
+        deletedTiles: deleteTiles,
+        deletedTeams: deleteTeams,
+        deletedParticipants: deleteParticipants,
+      }),
+    );
+
+    return bingo;
+  }
+
+  private async fetchBingo(requester: User, bingoId: string) {
+    const scope = new ViewBingoScope(
+      requester,
+      this.dataSource.createQueryBuilder(Bingo, 'bingo').where('bingo.bingo_id = :id', { id: bingoId }),
+    ).resolve();
+
+    const bingo = await scope.getOne();
+    if (!bingo) {
+      throw new NotFoundException(this.i18n.t('bingo.resetBingo.bingoNotFound'));
+    }
+
+    return bingo;
+  }
+
+  private async authorize(requester: User, bingo: Bingo) {
+    const bingoParticipant = await this.bingoParticipantRepository.findOneBy({
+      bingoId: bingo.id,
+      userId: requester.id,
+    });
+
+    if (!new BingoPolicies(requester, bingoParticipant).canReset()) {
+      throw new ForbiddenException(this.i18n.t('bingo.resetBingo.forbidden'));
+    }
+  }
+
+  private validateDates(startDate: string, endDate: string, maxRegistrationDate: string) {
+    const today = format(new Date(), 'yyyy-MM-dd');
+
+    if (isBefore(startDate, today)) {
+      throw new BadRequestException(this.i18n.t('bingo.resetBingo.startDateBeforeToday'));
+    }
+
+    if (isBefore(startDate, maxRegistrationDate)) {
+      throw new BadRequestException(this.i18n.t('bingo.resetBingo.startDateBeforeMaxRegistrationDate'));
+    }
+
+    if (endDate === startDate || isBefore(endDate, startDate)) {
+      throw new BadRequestException(this.i18n.t('bingo.resetBingo.endDateBeforeStartDate'));
+    }
+  }
+
+  private async deleteTiles(manager: EntityManager, bingo: Bingo) {
+    const tiles = await manager.findBy(BingoTile, { bingoId: bingo.id });
+    if (!tiles?.length) return;
+
+    await manager.delete(BingoTileItem, { bingoTileId: In(tiles.map((tile) => tile.id)) });
+    await manager.delete(BingoTile, { bingoId: bingo.id });
+  }
+
+  private async deleteParticipants(manager: EntityManager, bingo: Bingo, deleteTeams: boolean) {
+    // We must unassign all team captains if participants are deleted but not teams
+    if (!deleteTeams) await manager.update(BingoTeam, { bingoId: bingo.id }, { captainId: null });
+
+    await manager.delete(BingoParticipant, { bingoId: bingo.id });
+  }
+
+  private resetBingoLifecycle(
+    requester: User,
+    bingo: Bingo,
+    startDate: string,
+    endDate: string,
+    maxRegistrationDate: string,
+  ) {
+    bingo.startedAt = null;
+    bingo.startedById = null;
+    bingo.startedBy = Promise.resolve(null);
+
+    bingo.endedAt = null;
+    bingo.endedById = null;
+    bingo.endedBy = Promise.resolve(null);
+
+    bingo.canceledAt = null;
+    bingo.canceledById = null;
+    bingo.canceledBy = Promise.resolve(null);
+
+    bingo.resetAt = new Date();
+    bingo.resetById = requester.id;
+    bingo.resetBy = Promise.resolve(requester);
+
+    bingo.startDate = startDate;
+    bingo.endDate = endDate;
+    bingo.maxRegistrationDate = maxRegistrationDate;
+  }
+}

--- a/api/src/bingo/commands/start-bingo.command.spec.ts
+++ b/api/src/bingo/commands/start-bingo.command.spec.ts
@@ -1,0 +1,179 @@
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { EventBus } from '@nestjs/cqrs';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { addMonths, format, subDays } from 'date-fns';
+import { DataSource } from 'typeorm';
+
+import { configModule } from '@/config';
+import { dbModule } from '@/db';
+import { SeedingService } from '@/db/seeding/seeding.service';
+import { i18nModule } from '@/i18n';
+import { User } from '@/user/user.entity';
+
+import { StartBingoCommand, StartBingoHandler } from './start-bingo.command';
+import { BingoStatus } from '../bingo-status.enum';
+import { Bingo } from '../bingo.entity';
+import { BingoStartedEvent } from '../events/bingo-started.event';
+import { BingoParticipant } from '../participant/bingo-participant.entity';
+import { BingoRoles } from '../participant/roles/bingo-roles.constants';
+import { BingoTile } from '../tile/bingo-tile.entity';
+
+describe('StartBingoHandler', () => {
+  let module: TestingModule;
+  let seedingService: SeedingService;
+  let eventBus: jest.Mocked<EventBus>;
+  let handler: StartBingoHandler;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        configModule,
+        dbModule,
+        i18nModule,
+        TypeOrmModule.forFeature([Bingo, BingoParticipant, BingoTile, User]),
+      ],
+      providers: [
+        StartBingoHandler,
+        SeedingService,
+        {
+          provide: EventBus,
+          useValue: {
+            publish: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    handler = module.get(StartBingoHandler);
+    eventBus = module.get(EventBus);
+    seedingService = module.get(SeedingService);
+    dataSource = module.get(DataSource);
+  });
+
+  beforeEach(async () => {
+    await seedingService.initialize();
+  });
+
+  afterEach(async () => {
+    await seedingService.clear();
+  });
+
+  afterAll(() => {
+    return module.close();
+  });
+
+  it('throws NotFoundException if the requester is not allowed to see the bingo', async () => {
+    const requester = seedingService.getEntity(User, 'b0aty');
+    const bingo = seedingService.getEntity(Bingo, 'osrs-qc');
+
+    const command = new StartBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+    });
+
+    await expect(handler.execute(command)).rejects.toThrow(NotFoundException);
+  });
+
+  it('throws ForbiddenException if the requester is not a participant or a moderator', async () => {
+    const requester = seedingService.getEntity(User, 'b0aty');
+    const bingo = seedingService.getEntity(Bingo, 'ready_bingo');
+
+    const command = new StartBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+    });
+
+    await expect(handler.execute(command)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('throws BadRequestException if the bingo is not pending', async () => {
+    const requester = seedingService.getEntity(User, 'didiking');
+    const bingo = seedingService.getEntity(Bingo, 'started-bingo');
+
+    const command = new StartBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+    });
+
+    await expect(handler.execute(command)).rejects.toThrow(BadRequestException);
+  });
+
+  it('throws BadRequestException if the end date is in the past', async () => {
+    const requester = seedingService.getEntity(User, 'raph');
+    const bingo = seedingService.getEntity(Bingo, 'ready_bingo');
+
+    const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
+    await dataSource.manager.update(Bingo, bingo.id, { endDate: yesterday });
+
+    const command = new StartBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+    });
+
+    await expect(handler.execute(command)).rejects.toThrow(BadRequestException);
+  });
+
+  it('throws BadRequestException if not all tiles are present', async () => {
+    const requester = seedingService.getEntity(User, 'char0o');
+    const bingo = seedingService.getEntity(Bingo, 'osrs-qc');
+
+    const endDate = format(addMonths(new Date(), 1), 'yyyy-MM-dd');
+    const command = new StartBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+      endDate,
+    });
+
+    await expect(handler.execute(command)).rejects.toThrow(BadRequestException);
+  });
+
+  it('throws BadRequestException if not all participants are assigned to a team', async () => {
+    const requester = seedingService.getEntity(User, 'raph');
+    const bingo = seedingService.getEntity(Bingo, 'ready_bingo');
+    const user = seedingService.getEntity(User, 'zezima');
+
+    await dataSource.manager.insert(BingoParticipant, {
+      userId: user.id,
+      bingoId: bingo.id,
+      role: BingoRoles.Participant,
+    });
+
+    const command = new StartBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+    });
+
+    await expect(handler.execute(command)).rejects.toThrow(BadRequestException);
+  });
+
+  it('starts the bingo and emits a BingoStartedEvent', async () => {
+    const requester = seedingService.getEntity(User, 'raph');
+    const bingo = seedingService.getEntity(Bingo, 'ready_bingo');
+
+    const startDate = format(new Date(), 'yyyy-MM-dd');
+    const endDate = format(addMonths(new Date(), 1), 'yyyy-MM-dd');
+
+    const command = new StartBingoCommand({
+      requester,
+      bingoId: bingo.bingoId,
+      endDate,
+    });
+
+    const startedBingo = await handler.execute(command);
+    expect(startedBingo).toBeDefined();
+    expect(startedBingo.status).toBe(BingoStatus.Ongoing);
+    expect(startedBingo.endDate).toBe(endDate);
+    expect(startedBingo.startDate).toBe(startDate);
+    expect(startedBingo.startedAt).toBeDefined();
+    expect(startedBingo.startedById).toBe(requester.id);
+    await expect(startedBingo.updatedBy).resolves.toBe(requester);
+    await expect(startedBingo.startedBy).resolves.toBe(requester);
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(eventBus.publish).toHaveBeenCalledWith(
+      new BingoStartedEvent({ bingoId: bingo.id, requesterId: requester.id, endDate, early: true }),
+    );
+  });
+});

--- a/api/src/bingo/commands/start-bingo.command.ts
+++ b/api/src/bingo/commands/start-bingo.command.ts
@@ -1,0 +1,132 @@
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Command, CommandHandler, EventBus } from '@nestjs/cqrs';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { format } from 'date-fns';
+import { I18nService } from 'nestjs-i18n';
+import { Between, DataSource, IsNull, Repository } from 'typeorm';
+
+import { I18nTranslations } from '@/i18n/types';
+import { User } from '@/user/user.entity';
+
+import { BingoStatus } from '../bingo-status.enum';
+import { Bingo } from '../bingo.entity';
+import { BingoPolicies } from '../bingo.policies';
+import { BingoStartedEvent } from '../events/bingo-started.event';
+import { BingoParticipant } from '../participant/bingo-participant.entity';
+import { ViewBingoScope } from '../scopes/view-bingo.scope';
+import { BingoTile } from '../tile/bingo-tile.entity';
+
+export type StartBingoParams = {
+  requester: User;
+  bingoId: string;
+  endDate?: string;
+};
+
+export type StartBingoResult = Bingo;
+
+export class StartBingoCommand extends Command<StartBingoResult> {
+  constructor(public readonly params: StartBingoParams) {
+    super();
+    this.params = params;
+  }
+}
+
+@CommandHandler(StartBingoCommand)
+export class StartBingoHandler {
+  constructor(
+    private readonly eventBus: EventBus,
+    private readonly i18nService: I18nService<I18nTranslations>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+    @InjectRepository(Bingo)
+    private readonly bingoRepository: Repository<Bingo>,
+    @InjectRepository(BingoParticipant)
+    private readonly bingoParticipantRepository: Repository<BingoParticipant>,
+    @InjectRepository(BingoTile)
+    private readonly bingoTileRepository: Repository<BingoTile>,
+  ) {}
+
+  async execute(command: StartBingoCommand): Promise<StartBingoResult> {
+    const { requester, bingoId, endDate } = command.params;
+
+    let scope = this.bingoRepository.createQueryBuilder('bingo').where('bingo.bingoId = :bingoId', { bingoId });
+    scope = new ViewBingoScope(requester, scope).resolve();
+
+    const bingo = await scope.getOne();
+    if (!bingo) {
+      throw new NotFoundException(this.i18nService.t('bingo.startBingo.bingoNotFound'));
+    }
+
+    const bingoParticipant = await this.bingoParticipantRepository.findOneBy({
+      bingoId: bingo.id,
+      userId: requester.id,
+    });
+
+    if (!new BingoPolicies(requester, bingoParticipant).canStart()) {
+      throw new ForbiddenException(this.i18nService.t('bingo.startBingo.forbidden'));
+    }
+
+    if (bingo.status !== BingoStatus.Pending) {
+      throw new BadRequestException(this.i18nService.t('bingo.startBingo.notPending'));
+    }
+
+    this.validateEndDate(bingo, endDate);
+    await this.validateAllTilesPresent(bingo);
+    await this.validateAllParticipantsAssignedToTeams(bingo);
+
+    await this.dataSource.transaction(async (entityManager) => {
+      // TODO: cancel all pending applications
+      // TODO: cancel all pending invitations
+
+      bingo.updatedById = requester.id;
+      bingo.updatedBy = Promise.resolve(requester);
+
+      bingo.startDate = format(new Date(), 'yyyy-MM-dd');
+      bingo.startedAt = new Date();
+      bingo.startedById = requester.id;
+      bingo.startedBy = Promise.resolve(requester);
+
+      if (endDate) bingo.endDate = endDate;
+
+      await entityManager.save(bingo);
+    });
+
+    this.eventBus.publish(
+      new BingoStartedEvent({ bingoId: bingo.id, requesterId: requester.id, early: true, endDate }),
+    );
+
+    return bingo;
+  }
+
+  private validateEndDate(bingo: Bingo, endDate: string | undefined) {
+    const newEndDateString = endDate ?? bingo.endDate;
+    const newEndDate = new Date(newEndDateString);
+    if (newEndDate < new Date()) {
+      throw new BadRequestException(this.i18nService.t('bingo.startBingo.endDateBeforeNow'));
+    }
+  }
+
+  private async validateAllTilesPresent(bingo: Bingo) {
+    const expectedTileCount = bingo.width * bingo.height;
+    const actualTileCount = await this.bingoTileRepository.countBy({
+      bingoId: bingo.id,
+      x: Between(1, bingo.width),
+      y: Between(1, bingo.height),
+    });
+
+    if (actualTileCount !== expectedTileCount) {
+      throw new BadRequestException(this.i18nService.t('bingo.startBingo.tilesNotPresent'));
+    }
+  }
+
+  private async validateAllParticipantsAssignedToTeams(bingo: Bingo) {
+    const orphanedParticipants = await this.bingoParticipantRepository.existsBy({
+      bingoId: bingo.id,
+      teamId: IsNull(),
+    });
+
+    if (orphanedParticipants) {
+      throw new BadRequestException(this.i18nService.t('bingo.startBingo.participantsNotAssignedToTeams'));
+    }
+  }
+}

--- a/api/src/bingo/commands/start-bingo.command.ts
+++ b/api/src/bingo/commands/start-bingo.command.ts
@@ -13,6 +13,7 @@ import { Bingo } from '../bingo.entity';
 import { BingoPolicies } from '../bingo.policies';
 import { BingoStartedEvent } from '../events/bingo-started.event';
 import { BingoParticipant } from '../participant/bingo-participant.entity';
+import { BingoRoles } from '../participant/roles/bingo-roles.constants';
 import { ViewBingoScope } from '../scopes/view-bingo.scope';
 import { BingoTile } from '../tile/bingo-tile.entity';
 
@@ -123,6 +124,7 @@ export class StartBingoHandler {
     const orphanedParticipants = await this.bingoParticipantRepository.existsBy({
       bingoId: bingo.id,
       teamId: IsNull(),
+      role: BingoRoles.Participant,
     });
 
     if (orphanedParticipants) {

--- a/api/src/bingo/dto/bingo.dto.ts
+++ b/api/src/bingo/dto/bingo.dto.ts
@@ -14,6 +14,7 @@ export class BingoDto {
       endedBy?: UserDto;
       canceledBy?: UserDto;
       deletedBy?: UserDto;
+      resetBy?: UserDto;
     },
   ) {
     this.language = bingo.language;
@@ -36,6 +37,8 @@ export class BingoDto {
     this.canceledAt = bingo.canceledAt;
     this.canceledBy = users?.canceledBy;
     this.deletedBy = users?.deletedBy;
+    this.resetAt = bingo.resetAt;
+    this.resetBy = users?.resetBy;
   }
 
   @ApiProperty()
@@ -97,6 +100,12 @@ export class BingoDto {
 
   @ApiProperty()
   deletedBy: UserDto | undefined;
+
+  @ApiProperty()
+  resetAt: Date | null;
+
+  @ApiProperty()
+  resetBy: UserDto | undefined;
 
   @ApiProperty()
   maxRegistrationDate?: string;

--- a/api/src/bingo/dto/reset-bingo.dto.ts
+++ b/api/src/bingo/dto/reset-bingo.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsISO8601, IsOptional } from 'class-validator';
+
+export class ResetBingoDto {
+  @ApiProperty()
+  @IsISO8601()
+  startDate: string;
+
+  @ApiProperty()
+  @IsISO8601()
+  endDate: string;
+
+  @ApiProperty()
+  @IsISO8601()
+  maxRegistrationDate: string;
+
+  @ApiProperty()
+  @IsBoolean()
+  @IsOptional()
+  deleteTiles?: boolean;
+
+  @ApiProperty()
+  @IsBoolean()
+  @IsOptional()
+  deleteTeams?: boolean;
+
+  @ApiProperty()
+  @IsBoolean()
+  @IsOptional()
+  deleteParticipants?: boolean;
+}

--- a/api/src/bingo/dto/start-bingo.dto.ts
+++ b/api/src/bingo/dto/start-bingo.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsISO8601, IsOptional } from 'class-validator';
+
+export class StartBingoDto {
+  @ApiProperty()
+  @IsOptional()
+  @IsISO8601()
+  endDate?: string;
+}

--- a/api/src/bingo/events/bingo-ended.event.ts
+++ b/api/src/bingo/events/bingo-ended.event.ts
@@ -1,0 +1,32 @@
+import { CommandBus, EventsHandler } from '@nestjs/cqrs';
+
+import { CreateActivityCommand } from '@/activity/commands/create-activity.command';
+
+export type BingoEndedParams = {
+  bingoId: number;
+  requesterId: number;
+  early?: boolean;
+};
+
+export class BingoEndedEvent {
+  constructor(public readonly params: BingoEndedParams) {}
+}
+
+@EventsHandler(BingoEndedEvent)
+export class BingoEndedHandler {
+  constructor(private readonly commandBus: CommandBus) {}
+
+  async handle(event: BingoEndedEvent) {
+    const { bingoId, requesterId, early = false } = event.params;
+
+    await this.commandBus.execute(
+      new CreateActivityCommand({
+        key: 'bingo.ended',
+        requesterId,
+        trackableId: bingoId,
+        trackableType: 'Bingo',
+        parameters: { early },
+      }),
+    );
+  }
+}

--- a/api/src/bingo/events/bingo-reset.event.ts
+++ b/api/src/bingo/events/bingo-reset.event.ts
@@ -1,0 +1,53 @@
+import { CommandBus, EventsHandler } from '@nestjs/cqrs';
+
+import { CreateActivityCommand } from '@/activity/commands/create-activity.command';
+
+export type BingoResetParams = {
+  bingoId: number;
+  requesterId: number;
+  startDate: string;
+  endDate: string;
+  maxRegistrationDate: string;
+  deletedTiles: boolean;
+  deletedTeams: boolean;
+  deletedParticipants: boolean;
+};
+
+export class BingoResetEvent {
+  constructor(public readonly params: BingoResetParams) {}
+}
+
+@EventsHandler(BingoResetEvent)
+export class BingoResetHandler {
+  constructor(private readonly commandBus: CommandBus) {}
+
+  async handle(event: BingoResetEvent) {
+    const {
+      bingoId,
+      requesterId,
+      startDate,
+      endDate,
+      maxRegistrationDate,
+      deletedTiles,
+      deletedTeams,
+      deletedParticipants,
+    } = event.params;
+
+    await this.commandBus.execute(
+      new CreateActivityCommand({
+        key: 'bingo.reset',
+        requesterId,
+        trackableType: 'bingo',
+        trackableId: bingoId,
+        parameters: {
+          startDate,
+          endDate,
+          maxRegistrationDate,
+          deletedTiles,
+          deletedTeams,
+          deletedParticipants,
+        },
+      }),
+    );
+  }
+}

--- a/api/src/bingo/events/bingo-started.event.ts
+++ b/api/src/bingo/events/bingo-started.event.ts
@@ -1,0 +1,36 @@
+import { CommandBus, EventsHandler } from '@nestjs/cqrs';
+
+import { CreateActivityCommand } from '@/activity/commands/create-activity.command';
+
+export type BingoStartedParams = {
+  bingoId: number;
+  requesterId: number;
+  early?: boolean;
+  endDate?: string;
+};
+
+export class BingoStartedEvent {
+  constructor(public readonly params: BingoStartedParams) {}
+}
+
+@EventsHandler(BingoStartedEvent)
+export class BingoStartedHandler {
+  constructor(private readonly commandBus: CommandBus) {}
+
+  async handle(event: BingoStartedEvent) {
+    const { bingoId, requesterId, early = false, endDate } = event.params;
+
+    await this.commandBus.execute(
+      new CreateActivityCommand({
+        key: 'bingo.started',
+        requesterId,
+        trackableId: bingoId,
+        trackableType: 'Bingo',
+        parameters: {
+          early,
+          ...(endDate ? { endDate } : {}),
+        },
+      }),
+    );
+  }
+}

--- a/api/src/bingo/participant/dto/bingo-participant.dto.ts
+++ b/api/src/bingo/participant/dto/bingo-participant.dto.ts
@@ -3,6 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { UserDto } from '@/user/dto/user.dto';
 
 import { BingoParticipant } from '../bingo-participant.entity';
+import { BingoRoles } from '../roles/bingo-roles.constants';
 
 export class BingoParticipantDto {
   constructor(bingoParticipant: BingoParticipant) {
@@ -33,6 +34,6 @@ export class BingoParticipantDto {
   @ApiProperty()
   user: UserDto | null;
 
-  @ApiProperty()
-  role: string;
+  @ApiProperty({ enum: BingoRoles, enumName: 'BingoRoles' })
+  role: BingoRoles;
 }

--- a/api/src/bingo/queries/search-bingo-activities.query.ts
+++ b/api/src/bingo/queries/search-bingo-activities.query.ts
@@ -53,8 +53,8 @@ export class SearchBingoActivitiesHandler {
       userId: requester.id,
     });
 
-    if (!new BingoPolicies(requester).canViewActivities(bingoParticipant)) {
-      throw new ForbiddenException(); // this.i18nService.t('bingo.activity.forbidden')
+    if (!new BingoPolicies(requester, bingoParticipant).canViewActivities()) {
+      throw new ForbiddenException(this.i18nService.t('bingo.searchBingoActivities.forbidden'));
     }
 
     const q = this.activityRepository

--- a/api/src/bingo/scopes/view-bingo.scope.ts
+++ b/api/src/bingo/scopes/view-bingo.scope.ts
@@ -13,7 +13,7 @@ export class ViewBingoScope extends Scope<Bingo> {
     if (userHasRole(this.requester, Roles.Moderator)) return this.query;
 
     return this.query.andWhere(
-      'exists (select 1 from bingo_participant where bingo_id = bingo.id and user_id = :requesterId)',
+      '(bingo.private = false OR exists (select 1 from bingo_participant where bingo_id = bingo.id and user_id = :requesterId))',
       {
         requesterId: this.requester.id,
       },

--- a/api/src/bingo/team/bingo-team.entity.ts
+++ b/api/src/bingo/team/bingo-team.entity.ts
@@ -21,12 +21,12 @@ export class BingoTeam extends StrongEntityParanoid {
   @Column()
   nameNormalized: string;
 
-  @Column({ name: 'captain_id', type: 'int' })
-  captainId: number;
+  @Column({ name: 'captain_id', type: 'int', nullable: true })
+  captainId: number | null;
 
   @ManyToOne(() => User)
   @JoinColumn({ name: 'captain_id' })
-  captain: Promise<User>;
+  captain: Promise<User | null>;
 
   @Column({ default: 0 })
   points: number;

--- a/api/src/db/migrations/1751417271509-add-bingo-reset-at-and-make-bingo-team-captain-nullable.ts
+++ b/api/src/db/migrations/1751417271509-add-bingo-reset-at-and-make-bingo-team-captain-nullable.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddBingoResetAtAndMakeBingoTeamCaptainNullable1751417271509 implements MigrationInterface {
+    name = 'AddBingoResetAtAndMakeBingoTeamCaptainNullable1751417271509'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "bingo" ADD "reset_at" TIMESTAMP WITH TIME ZONE`);
+        await queryRunner.query(`ALTER TABLE "bingo" ADD "reset_by" integer`);
+        await queryRunner.query(`ALTER TABLE "bingo_team" DROP CONSTRAINT "FK_4215ce5c904794a3bb44c13a896"`);
+        await queryRunner.query(`ALTER TABLE "bingo_team" ALTER COLUMN "captain_id" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "bingo_team" ADD CONSTRAINT "FK_4215ce5c904794a3bb44c13a896" FOREIGN KEY ("captain_id") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "bingo" ADD CONSTRAINT "FK_ad74131cadf8a42ded86a0b1dbd" FOREIGN KEY ("reset_by") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "bingo" DROP CONSTRAINT "FK_ad74131cadf8a42ded86a0b1dbd"`);
+        await queryRunner.query(`ALTER TABLE "bingo_team" DROP CONSTRAINT "FK_4215ce5c904794a3bb44c13a896"`);
+        await queryRunner.query(`ALTER TABLE "bingo_team" ALTER COLUMN "captain_id" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "bingo_team" ADD CONSTRAINT "FK_4215ce5c904794a3bb44c13a896" FOREIGN KEY ("captain_id") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "bingo" DROP COLUMN "reset_by"`);
+        await queryRunner.query(`ALTER TABLE "bingo" DROP COLUMN "reset_at"`);
+    }
+
+}

--- a/api/src/db/seeding/development/bingo-participant.yml
+++ b/api/src/db/seeding/development/bingo-participant.yml
@@ -48,3 +48,27 @@ dee420-ready:
   bingo: ready_bingo
   role: participant
   team: ready-red
+
+raph-lifecycle:
+  user: raph
+  bingo: lifecycle-bingo
+  role: owner
+  team: lifecycle-blue
+
+char0o-lifecycle:
+  user: char0o
+  bingo: lifecycle-bingo
+  role: organizer
+  team: lifecycle-blue
+
+didiking-lifecycle:
+  user: didiking
+  bingo: lifecycle-bingo
+  role: participant
+  team: lifecycle-red
+
+dee420-lifecycle:
+  user: dee420
+  bingo: lifecycle-bingo
+  role: participant
+  team: lifecycle-red

--- a/api/src/db/seeding/development/bingo-team.yml
+++ b/api/src/db/seeding/development/bingo-team.yml
@@ -21,3 +21,15 @@ ready-red:
   bingo: ready_bingo
   captain: char0o
   points: 0
+
+lifecycle-blue:
+  name: Blue team
+  bingo: lifecycle-bingo
+  captain: raph
+  points: 100
+
+lifecycle-red:
+  name: Red team
+  bingo: lifecycle-bingo
+  captain: didiking
+  points: 50

--- a/api/src/db/seeding/development/bingo-tile-item.yml
+++ b/api/src/db/seeding/development/bingo-tile-item.yml
@@ -138,3 +138,8 @@ ready_3-3_ranger_boots:
   index: 0
   tile: ready_3-3
   item: ranger_boots
+
+lifecycle_1-1_ranger_boots:
+  index: 0
+  tile: lifecycle_1-1
+  item: ranger_boots

--- a/api/src/db/seeding/development/bingo-tile.yml
+++ b/api/src/db/seeding/development/bingo-tile.yml
@@ -103,3 +103,13 @@ ready_3-3:
   description: You know what to do. Go hunt those eclectic implings!
   completionMode: all
   imageUrl: https://chisel.weirdgloop.org/static/img/osrs-dii/2577.png
+
+lifecycle_1-1:
+  bingo: lifecycle-bingo
+  x: 1
+  y: 1
+  value: 1
+  title: Lifecycle bingo
+  description: Lifecycle bingo
+  completionMode: all
+  imageUrl: https://chisel.weirdgloop.org/static/img/osrs-dii/2577.png

--- a/api/src/db/seeding/development/bingo.yml
+++ b/api/src/db/seeding/development/bingo.yml
@@ -100,3 +100,20 @@ ready_bingo:
   startDate: '2036-01-01'
   endDate: '2036-03-01'
   maxRegistrationDate: '2035-12-01'
+
+lifecycle-bingo:
+  bingoId: 00000000-0000-0000-0000-000000000008
+  createdBy: raph
+  language: 'en'
+  title: 'lifecycle bingo'
+  description: 'Im a bingo that has went through a full lifecycle'
+  private: true
+  width: 1
+  height: 1
+  fullLineValue: 10
+  startDate: '2025-04-01'
+  endDate: '2025-04-30'
+  maxRegistrationDate: '2025-03-31'
+  canceledAt: '2025-05-01'
+  startedAt: '2025-04-01'
+  endedAt: '2025-04-30'

--- a/api/src/db/seeding/test/bingo-participant.yml
+++ b/api/src/db/seeding/test/bingo-participant.yml
@@ -63,3 +63,27 @@ dee420-ready:
   bingo: ready_bingo
   role: participant
   team: ready-red
+
+raph-lifecycle:
+  user: raph
+  bingo: lifecycle-bingo
+  role: owner
+  team: lifecycle-blue
+
+char0o-lifecycle:
+  user: char0o
+  bingo: lifecycle-bingo
+  role: organizer
+  team: lifecycle-blue
+
+didiking-lifecycle:
+  user: didiking
+  bingo: lifecycle-bingo
+  role: participant
+  team: lifecycle-red
+
+dee420-lifecycle:
+  user: dee420
+  bingo: lifecycle-bingo
+  role: participant
+  team: lifecycle-red

--- a/api/src/db/seeding/test/bingo-team.yml
+++ b/api/src/db/seeding/test/bingo-team.yml
@@ -21,3 +21,15 @@ ready-red:
   bingo: ready_bingo
   captain: char0o
   points: 0
+
+lifecycle-blue:
+  name: Blue team
+  bingo: lifecycle-bingo
+  captain: raph
+  points: 100
+
+lifecycle-red:
+  name: Red team
+  bingo: lifecycle-bingo
+  captain: didiking
+  points: 50

--- a/api/src/db/seeding/test/bingo-tile-item.yml
+++ b/api/src/db/seeding/test/bingo-tile-item.yml
@@ -138,3 +138,8 @@ ready_3-3_ranger_boots:
   index: 0
   tile: ready_3-3
   item: ranger_boots
+
+lifecycle_1-1_ranger_boots:
+  index: 0
+  tile: lifecycle_1-1
+  item: ranger_boots

--- a/api/src/db/seeding/test/bingo-tile.yml
+++ b/api/src/db/seeding/test/bingo-tile.yml
@@ -103,3 +103,13 @@ ready_3-3:
   description: You know what to do. Go hunt those eclectic implings!
   completionMode: all
   imageUrl: https://chisel.weirdgloop.org/static/img/osrs-dii/2577.png
+
+lifecycle_1-1:
+  bingo: lifecycle-bingo
+  x: 1
+  y: 1
+  value: 1
+  title: Lifecycle bingo
+  description: Lifecycle bingo
+  completionMode: all
+  imageUrl: https://chisel.weirdgloop.org/static/img/osrs-dii/2577.png

--- a/api/src/db/seeding/test/bingo.yml
+++ b/api/src/db/seeding/test/bingo.yml
@@ -100,3 +100,20 @@ ready_bingo:
   startDate: '2036-01-01'
   endDate: '2036-03-01'
   maxRegistrationDate: '2035-12-01'
+
+lifecycle-bingo:
+  bingoId: 00000000-0000-0000-0000-000000000008
+  createdBy: raph
+  language: 'en'
+  title: 'lifecycle bingo'
+  description: 'Im a bingo that has went through a full lifecycle'
+  private: true
+  width: 1
+  height: 1
+  fullLineValue: 10
+  startDate: '2025-04-01'
+  endDate: '2025-04-30'
+  maxRegistrationDate: '2025-03-31'
+  canceledAt: '2025-05-01'
+  startedAt: '2025-04-01'
+  endedAt: '2025-04-30'

--- a/api/src/i18n/en/bingo.json
+++ b/api/src/i18n/en/bingo.json
@@ -32,7 +32,29 @@
     "alreadyCanceled": "Bingo is already canceled."
   },
   "searchBingoActivities": {
-    "bingoNotFound": "No bingo with this id was found."
+    "bingoNotFound": "No bingo with this id was found.",
+    "forbidden": "You are not authorized to view the activities of this bingo."
+  },
+  "startBingo": {
+    "bingoNotFound": "No bingo with this id was found.",
+    "forbidden": "You are not authorized to start this bingo.",
+    "notPending": "The bingo is not pending.",
+    "endDateBeforeNow": "The end date must be in the future. Please provide a new end date.",
+    "tilesNotPresent": "All tiles must be present.",
+    "participantsNotAssignedToTeams": "All participants must be assigned to teams."
+  },
+  "endBingo": {
+    "bingoNotFound": "No bingo with this id was found.",
+    "forbidden": "You are not authorized to end this bingo.",
+    "notOngoing": "The bingo is not ongoing."
+  },
+  "resetBingo": {
+    "bingoNotFound": "No bingo with this id was found.",
+    "forbidden": "You are not authorized to reset this bingo.",
+    "notCanceled": "The bingo is not canceled.",
+    "startDateBeforeToday": "The start date must be in the future.",
+    "startDateBeforeMaxRegistrationDate": "The start date must be before the max registration date.",
+    "endDateBeforeStartDate": "The end date must be after the start date."
   },
   "activity": {
     "created": {
@@ -52,19 +74,38 @@
         "endDate": "Set the end date to {endDate}."
       }
     },
+    "started": {
+      "title": "{username} has started the bingo.",
+      "titleEarly": "{username} has started the bingo early.",
+      "body": {
+        "endDate": "Set the end date to {endDate}."
+      }
+    },
+    "ended": {
+      "title": "{username} has ended the bingo.",
+      "titleEarly": "{username} has ended the bingo early."
+    },
     "deleted": {
       "title": "{username} has deleted the bingo."
     },
     "canceled": {
       "title": "{username} has canceled the bingo."
     },
+    "reset": {
+      "title": "{username} has reset the bingo.",
+      "body": {
+        "startDate": "Set the start date to {startDate}.",
+        "endDate": "Set the end date to {endDate}.",
+        "maxRegistrationDate": "Set the max registration date to {maxRegistrationDate}.",
+        "deletedTiles": "Deleted the tiles.",
+        "deletedTeams": "Deleted the teams.",
+        "deletedParticipants": "Deleted the participants."
+      }
+    },
     "cancelBingo": {
       "bingoNotFound": "No bingo with this id was found.",
       "forbidden": "You are not authorized to cancel this bingo.",
       "alreadyCanceled": "Bingo is already canceled."
-    },
-    "searchBingoActivities": {
-      "bingoNotFound": "No bingo with this id was found."
     },
     "findBingoByBingoId": {
       "bingoNotFound": {

--- a/api/src/i18n/fr/bingo.json
+++ b/api/src/i18n/fr/bingo.json
@@ -31,10 +31,32 @@
     "alreadyCanceled": "Le bingo est déjà annulé."
   },
   "searchBingoActivities": {
-    "bingoNotFound": "Aucun bingo avec ce id n'a été trouvé."
+    "bingoNotFound": "Aucun bingo avec ce id n'a été trouvé.",
+    "forbidden": "Vous n'êtes pas autorisé à voir les activités de ce bingo."
   },
   "formatBingoActivities": {
     "title": "Bingo {action} par {username}."
+  },
+  "startBingo": {
+    "bingoNotFound": "Aucun bingo avec ce id n'a été trouvé.",
+    "forbidden": "Vous n'êtes pas autorisé à démarrer ce bingo.",
+    "notPending": "Le bingo n'est pas en attente.",
+    "endDateBeforeNow": "La date de fin doit être dans le futur. Veuillez fournir une nouvelle date de fin.",
+    "tilesNotPresent": "Toutes les cases doivent être présentes.",
+    "participantsNotAssignedToTeams": "Tous les participants doivent être assignés à des équipes."
+  },
+  "endBingo": {
+    "bingoNotFound": "Aucun bingo avec ce id n'a été trouvé.",
+    "forbidden": "Vous n'êtes pas autorisé à terminer ce bingo.",
+    "notOngoing": "Le bingo n'est pas en cours."
+  },
+  "resetBingo": {
+    "bingoNotFound": "Aucun bingo avec cet id n'a été trouvé.",
+    "forbidden": "Vous n'êtes pas autorisé à réinitialiser ce bingo.",
+    "notCanceled": "Le bingo n'est pas annulé.",
+    "startDateBeforeToday": "La date de début doit être dans le futur.",
+    "startDateBeforeMaxRegistrationDate": "La date de début doit être avant la date limite d'enregistrement.",
+    "endDateBeforeStartDate": "La date de fin doit être après la date de début."
   },
   "findBingoByBingoId": {
     "bingoNotFound": {
@@ -61,19 +83,38 @@
         "endDate": "A mis à jour le date de fin au {endDate}."
       }
     },
+    "started": {
+      "title": "{username} a démarré le bingo.",
+      "titleEarly": "{username} a démarré le bingo en avance.",
+      "body": {
+        "endDate": "A mis à jour la date de fin au {endDate}."
+      }
+    },
+    "ended": {
+      "title": "{username} a terminé le bingo.",
+      "titleEarly": "{username} a terminé le bingo en avance."
+    },
     "deleted": {
       "title": "{username} a supprimé le bingo."
     },
     "canceled": {
       "title": "{username} a annulé le bingo."
     },
+    "reset": {
+      "title": "{username} a réinitialisé le bingo.",
+      "body": {
+        "startDate": "A mis à jour la date de début au {startDate}.",
+        "endDate": "A mis à jour le date de fin au {endDate}.",
+        "maxRegistrationDate": "A mis à jour la date limite d'enregistrement au {maxRegistrationDate}.",
+        "deletedTiles": "A supprimé les cases.",
+        "deletedTeams": "A supprimé les équipes.",
+        "deletedParticipants": "A supprimé les participants."
+      }
+    },
     "cancelBingo": {
       "bingoNotFound": "Aucun bingo avec ce id n'a été trouvé.",
       "forbidden": "Vous n'êtes pas autorisé à annuler ce bingo.",
       "alreadyCanceled": "Le bingo est déjà annulé."
-    },
-    "searchBingoActivities": {
-      "bingoNotFound": "Aucun bingo avec ce id n'a été trouvé."
     },
     "formatBingoActivities": {
       "title": "Bingo {action} par {username}."

--- a/api/src/i18n/types.ts
+++ b/api/src/i18n/types.ts
@@ -93,6 +93,28 @@ export type I18nTranslations = {
         };
         "searchBingoActivities": {
             "bingoNotFound": string;
+            "forbidden": string;
+        };
+        "startBingo": {
+            "bingoNotFound": string;
+            "forbidden": string;
+            "notPending": string;
+            "endDateBeforeNow": string;
+            "tilesNotPresent": string;
+            "participantsNotAssignedToTeams": string;
+        };
+        "endBingo": {
+            "bingoNotFound": string;
+            "forbidden": string;
+            "notOngoing": string;
+        };
+        "resetBingo": {
+            "bingoNotFound": string;
+            "forbidden": string;
+            "notCanceled": string;
+            "startDateBeforeToday": string;
+            "startDateBeforeMaxRegistrationDate": string;
+            "endDateBeforeStartDate": string;
         };
         "activity": {
             "created": {
@@ -112,19 +134,38 @@ export type I18nTranslations = {
                     "endDate": string;
                 };
             };
+            "started": {
+                "title": string;
+                "titleEarly": string;
+                "body": {
+                    "endDate": string;
+                };
+            };
+            "ended": {
+                "title": string;
+                "titleEarly": string;
+            };
             "deleted": {
                 "title": string;
             };
             "canceled": {
                 "title": string;
             };
+            "reset": {
+                "title": string;
+                "body": {
+                    "startDate": string;
+                    "endDate": string;
+                    "maxRegistrationDate": string;
+                    "deletedTiles": string;
+                    "deletedTeams": string;
+                    "deletedParticipants": string;
+                };
+            };
             "cancelBingo": {
                 "bingoNotFound": string;
                 "forbidden": string;
                 "alreadyCanceled": string;
-            };
-            "searchBingoActivities": {
-                "bingoNotFound": string;
             };
             "findBingoByBingoId": {
                 "bingoNotFound": {

--- a/frontend/src/api/bingo.ts
+++ b/frontend/src/api/bingo.ts
@@ -1,11 +1,13 @@
-import { _delete, get, put, type PaginatedQueryParams } from '.';
-import type {
-  BingoDto,
-  BingoTileDto,
-  CreateOrEditBingoTileDto,
-  DetailedBingoTileDto,
-  PaginatedBingosDto,
-  UpdateBingoDto,
+import { _delete, get, post, put, type PaginatedQueryParams } from '.';
+import {
+  type StartBingoDto,
+  type BingoDto,
+  type BingoTileDto,
+  type CreateOrEditBingoTileDto,
+  type DetailedBingoTileDto,
+  type PaginatedBingosDto,
+  type UpdateBingoDto,
+  type ResetBingoDto,
 } from './types';
 
 type SearchBingosParams = PaginatedQueryParams<{
@@ -61,4 +63,24 @@ export async function moveBingoTile(bingoId: string, x: number, y: number, toX: 
 
 export async function updateBingo(bingoId: string, updates: UpdateBingoDto) {
   return put<UpdateBingoDto, BingoDto>(`/bingo/${bingoId}`, updates);
+}
+
+export async function startBingo(bingoId: string, endDate?: string) {
+  return post<StartBingoDto, BingoDto>(`/bingo/${bingoId}/start`, { endDate });
+}
+
+export async function endBingo(bingoId: string) {
+  return post<void, BingoDto>(`/bingo/${bingoId}/end`);
+}
+
+export async function cancelBingo(bingoId: string) {
+  return post<void, BingoDto>(`/bingo/${bingoId}/cancel`);
+}
+
+export async function deleteBingo(bingoId: string) {
+  return _delete(`/bingo/${bingoId}`);
+}
+
+export async function resetBingo(bingoId: string, data: ResetBingoDto) {
+  return post<ResetBingoDto, BingoDto>(`/bingo/${bingoId}/reset`, data);
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -158,7 +158,7 @@ export type BingoParticipantDto = {
   teamName: string | null;
   teamNameNormalized: string | null;
   user: UserDto | null;
-  role: string;
+  role: BingoRoles;
 };
 
 export type UpdateBingoDto = {
@@ -175,11 +175,24 @@ export type UpdateBingoDto = {
   confirmTileDeletion?: boolean;
 };
 
+export type StartBingoDto = {
+  endDate?: string;
+};
+
 export type ShortBingoDto = {
   id: string;
   title: string;
   status: BingoStatus;
   role: BingoRoles;
+};
+
+export type ResetBingoDto = {
+  startDate: string;
+  endDate: string;
+  maxRegistrationDate: string;
+  deleteTiles?: boolean;
+  deleteTeams?: boolean;
+  deleteParticipants?: boolean;
 };
 
 export type PaginatedBingosDto = PaginatedDtoWithoutTotal<BingoDto> & {
@@ -220,6 +233,8 @@ export type BingoDto = {
   canceledAt: Date | null;
   canceledBy: UserDto | undefined;
   deletedBy: UserDto | undefined;
+  resetAt: Date | null;
+  resetBy: UserDto | undefined;
   maxRegistrationDate?: string;
 };
 

--- a/frontend/src/app/[locale]/bingo/[bingoId]/actions/actions-dropdown.tsx
+++ b/frontend/src/app/[locale]/bingo/[bingoId]/actions/actions-dropdown.tsx
@@ -4,7 +4,6 @@ import { ChevronDownIcon } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Fragment, useState } from 'react';
 
-import { type BingoDto } from '@/api/types';
 import { Button } from '@/design-system/ui/button';
 import {
   DropdownMenu,
@@ -18,17 +17,13 @@ import { ACTION_GROUPS } from './constants';
 import { useActionsContext } from './provider';
 import { type ActionKey, type Action } from './types';
 
-type ActionProps = {
-  bingo: BingoDto;
-};
-
-export default function ActionsDropdown({ bingo }: ActionProps) {
+export default function ActionsDropdown() {
   const [open, onOpenChange] = useState(false);
   const t = useTranslations('bingo.bingoCard.actionsDropdown');
-  const { callAction } = useActionsContext();
+  const { bingo, participant, callAction } = useActionsContext();
 
   const filteredActionGroups = ACTION_GROUPS.map((group) => {
-    const groupFiltered = group.filter((action) => action.visible(bingo));
+    const groupFiltered = group.filter((action) => action.visible({ bingo, participant }));
     return groupFiltered.length > 0 ? groupFiltered : null;
   }).filter(Boolean) as Action[][];
 

--- a/frontend/src/app/[locale]/bingo/[bingoId]/actions/actions.tsx
+++ b/frontend/src/app/[locale]/bingo/[bingoId]/actions/actions.tsx
@@ -1,25 +1,25 @@
 'use client';
 
-import { Fragment } from 'react';
-
 import ActionsDropdown from './actions-dropdown';
+import CancelBingo from './cancel-bingo';
+import DeleteBingo from './delete-bingo';
 import EditDetails from './edit-details';
+import EndBingo from './end-bingo';
 import ActionsProvider from './provider';
-import type { ActionsProps } from './types';
+import ResetBingo from './reset-bingo';
+import StartBingo from './start-bingo';
+import type { ActionsProviderProps } from './types';
 
-function Actions({ bingo }: ActionsProps) {
+export default function Actions(actionsProviderProps: ActionsProviderProps) {
   return (
-    <Fragment>
-      <ActionsDropdown bingo={bingo} />
+    <ActionsProvider {...actionsProviderProps}>
+      <ActionsDropdown />
+      <CancelBingo />
+      <DeleteBingo />
       <EditDetails />
-    </Fragment>
-  );
-}
-
-export default function ActionsWithProvider({ bingo }: ActionsProps) {
-  return (
-    <ActionsProvider bingo={bingo}>
-      <Actions bingo={bingo} />
+      <EndBingo />
+      <ResetBingo />
+      <StartBingo />
     </ActionsProvider>
   );
 }

--- a/frontend/src/app/[locale]/bingo/[bingoId]/actions/cancel-bingo.tsx
+++ b/frontend/src/app/[locale]/bingo/[bingoId]/actions/cancel-bingo.tsx
@@ -1,0 +1,30 @@
+import { useTranslations } from 'next-intl';
+
+import Modal from '@/design-system/components/modal';
+import { Button } from '@/design-system/ui/button';
+
+import { useActionsContext } from './provider';
+
+export default function CancelBingo() {
+  const { currentAction, closeAction, cancelBingo } = useActionsContext();
+  const t = useTranslations('bingo.bingoCard.cancelBingo');
+
+  return (
+    <Modal open={currentAction === 'cancel'} onOpenChange={closeAction}>
+      <Modal.Header title={t('title')} />
+      <Modal.Body>
+        {t.rich('descriptionHtml', {
+          p: (chunks) => <p className="text-sm text-muted-foreground">{chunks}</p>,
+        })}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="default" onClick={() => cancelBingo({ input: undefined })}>
+          {t('submit')}
+        </Button>
+        <Button variant="outline" onClick={closeAction}>
+          {t('cancel')}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/frontend/src/app/[locale]/bingo/[bingoId]/actions/constants.ts
+++ b/frontend/src/app/[locale]/bingo/[bingoId]/actions/constants.ts
@@ -1,46 +1,53 @@
 import { CalendarXIcon, CalendarClockIcon, PencilIcon, RecycleIcon, Trash2Icon } from 'lucide-react';
 
-import { type BingoDto, BingoStatus } from '@/api/types';
+import { BingoRoles, BingoStatus } from '@/api/types';
 
-import type { Action } from './types';
+import type { Action, ActionVisibleParams } from './types';
 
-export const ACTION_KEYS = ['cancel', 'delete', 'editDetails', 'endNow', 'reset', 'startNow'] as const;
+const actionVisibilityFor = (status: BingoStatus[] | 'all', roles: BingoRoles[]) => (params: ActionVisibleParams) =>
+  Boolean(
+    params.participant &&
+      (status === 'all' || status.includes(params.bingo.status)) &&
+      roles.includes(params.participant.role),
+  );
+
+export const ACTION_KEYS = ['cancel', 'delete', 'editDetails', 'end', 'reset', 'start'] as const;
 
 export const EDIT_DETAILS = {
   key: 'editDetails',
   icon: PencilIcon,
-  visible: ({ status }: BingoDto) => [BingoStatus.Pending, BingoStatus.Ongoing].includes(status),
+  visible: actionVisibilityFor([BingoStatus.Pending, BingoStatus.Ongoing], [BingoRoles.Owner, BingoRoles.Organizer]),
 } as const satisfies Action;
 
 export const RESET_EVENT = {
   key: 'reset',
   icon: RecycleIcon,
-  visible: ({ status }: BingoDto) => status === BingoStatus.Canceled,
+  visible: actionVisibilityFor([BingoStatus.Canceled], [BingoRoles.Owner]),
 } as const satisfies Action;
 
 export const START_NOW = {
-  key: 'startNow',
+  key: 'start',
   icon: CalendarClockIcon,
-  visible: ({ status }: BingoDto) => status === BingoStatus.Pending,
+  visible: actionVisibilityFor([BingoStatus.Pending], [BingoRoles.Owner, BingoRoles.Organizer]),
 } as const satisfies Action;
 
 export const END_NOW = {
-  key: 'endNow',
+  key: 'end',
   icon: CalendarClockIcon,
-  visible: ({ status }: BingoDto) => status === BingoStatus.Ongoing,
+  visible: actionVisibilityFor([BingoStatus.Ongoing], [BingoRoles.Owner, BingoRoles.Organizer]),
 } as const satisfies Action;
 
 export const CANCEL_EVENT = {
   key: 'cancel',
   icon: CalendarXIcon,
-  visible: ({ status }: BingoDto) => [BingoStatus.Pending, BingoStatus.Ongoing].includes(status),
+  visible: actionVisibilityFor([BingoStatus.Pending, BingoStatus.Ongoing], [BingoRoles.Owner]),
 } as const satisfies Action;
 
 export const DELETE_EVENT = {
   key: 'delete',
   icon: Trash2Icon,
   variant: 'destructive',
-  visible: () => true,
+  visible: actionVisibilityFor('all', [BingoRoles.Owner]),
 } as const satisfies Action;
 
 export const ACTION_GROUPS = [

--- a/frontend/src/app/[locale]/bingo/[bingoId]/actions/delete-bingo.tsx
+++ b/frontend/src/app/[locale]/bingo/[bingoId]/actions/delete-bingo.tsx
@@ -1,0 +1,28 @@
+import { useTranslations } from 'next-intl';
+
+import Modal from '@/design-system/components/modal';
+import { Button } from '@/design-system/ui/button';
+
+import { useActionsContext } from './provider';
+
+export default function DeleteBingo() {
+  const { currentAction, closeAction, deleteBingo } = useActionsContext();
+  const t = useTranslations('bingo.bingoCard.deleteBingo');
+
+  return (
+    <Modal open={currentAction === 'delete'} onOpenChange={closeAction}>
+      <Modal.Header title={t('title')} />
+      <Modal.Body>
+        <p className="text-sm text-muted-foreground">{t('description')}</p>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="destructive" onClick={() => deleteBingo({ input: undefined })}>
+          {t('submit')}
+        </Button>
+        <Button variant="outline" onClick={closeAction}>
+          {t('cancel')}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/frontend/src/app/[locale]/bingo/[bingoId]/actions/edit-details.tsx
+++ b/frontend/src/app/[locale]/bingo/[bingoId]/actions/edit-details.tsx
@@ -2,6 +2,7 @@ import { Form, FormikContext, useFormik } from 'formik';
 import { MoveRightIcon, XIcon } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 
+import { BingoStatus, type UpdateBingoDto } from '@/api/types';
 import BingoCardPreview from '@/common/bingo/card-preview';
 import DateField from '@/design-system/components/date-field';
 import Modal from '@/design-system/components/modal';
@@ -15,7 +16,20 @@ import { Separator } from '@/design-system/ui/separator';
 import { SUPPORTED_LOCALES } from '@/i18n';
 
 import { useActionsContext } from './provider';
-import type { FormValues } from './types';
+import type { UpdateBingoFormValues } from './types';
+
+const STATUS_RESTRICTIONS = {
+  language: [BingoStatus.Pending],
+  title: [BingoStatus.Pending, BingoStatus.Ongoing],
+  description: [BingoStatus.Pending, BingoStatus.Ongoing],
+  private: [BingoStatus.Pending],
+  startDate: [BingoStatus.Pending],
+  endDate: [BingoStatus.Pending, BingoStatus.Ongoing],
+  maxRegistrationDate: [BingoStatus.Pending],
+  width: [BingoStatus.Pending],
+  height: [BingoStatus.Pending],
+  fullLineValue: [BingoStatus.Pending],
+} as Readonly<Record<keyof Omit<UpdateBingoDto, 'confirmTileDeletion'>, BingoStatus[]>>;
 
 export default function EditDetails() {
   const { bingo, currentAction, closeAction, updateBingo } = useActionsContext();
@@ -23,7 +37,7 @@ export default function EditDetails() {
   const t = useTranslations('bingo.bingoCard.editDetails');
   const locale = useLocale();
 
-  const formik = useFormik<FormValues>({
+  const formik = useFormik<UpdateBingoFormValues>({
     initialValues: {
       language: bingo.language,
       title: bingo.title,
@@ -47,6 +61,9 @@ export default function EditDetails() {
 
   const { values, errors, setFieldValue, resetForm, handleSubmit } = formik;
   const submitDisabled = [values.width, values.height, values.fullLineValue].some((value) => value === null);
+  const disabledFields = Object.entries(STATUS_RESTRICTIONS)
+    .filter(([_, statuses]) => !statuses.includes(bingo.status))
+    .map(([field]) => field);
 
   const handleCancel = () => {
     resetForm();
@@ -66,6 +83,7 @@ export default function EditDetails() {
               value={values.language ?? ''}
               onChange={(value) => setFieldValue('language', value)}
               modal
+              disabled={disabledFields.includes('language')}
             />
             <TextField
               name="title"
@@ -73,6 +91,7 @@ export default function EditDetails() {
               value={values.title ?? ''}
               onChange={(value) => setFieldValue('title', value)}
               error={errors.title}
+              disabled={disabledFields.includes('title')}
             />
             <TextAreaField
               name="description"
@@ -80,6 +99,7 @@ export default function EditDetails() {
               value={values.description ?? ''}
               onChange={(value) => setFieldValue('description', value)}
               error={errors.description}
+              disabled={disabledFields.includes('description')}
             />
             <SwitchField
               name="public"
@@ -87,6 +107,7 @@ export default function EditDetails() {
               value={!values.private}
               onChange={(value) => setFieldValue('private', !value)}
               error={errors.private}
+              disabled={disabledFields.includes('private')}
             />
             <Separator className="my-5" />
             <div className="flex items-center gap-2.5 w-full">
@@ -98,6 +119,7 @@ export default function EditDetails() {
                 onChange={(value) => setFieldValue('startDate', value)}
                 error={errors.startDate}
                 modal
+                disabled={disabledFields.includes('startDate')}
               />
               <MoveRightIcon className="size-6 mt-1 shrink-0 text-gray-500" />
               <DateField
@@ -108,6 +130,7 @@ export default function EditDetails() {
                 onChange={(value) => setFieldValue('endDate', value)}
                 error={errors.endDate}
                 modal
+                disabled={disabledFields.includes('endDate')}
               />
             </div>
             <DateField
@@ -117,6 +140,7 @@ export default function EditDetails() {
               value={values.maxRegistrationDate ?? ''}
               onChange={(value) => setFieldValue('maxRegistrationDate', value)}
               error={errors.maxRegistrationDate}
+              disabled={disabledFields.includes('maxRegistrationDate')}
             />
             <Separator className="my-5" />
             <BingoCardPreview width={values.width} height={values.height} />
@@ -130,6 +154,7 @@ export default function EditDetails() {
                 value={values.width}
                 onChange={(value) => setFieldValue('width', value)}
                 error={errors.width}
+                disabled={disabledFields.includes('width')}
               />
               <XIcon className="size-6 mt-1 shrink-0 text-gray-500" />
               <NumberField
@@ -141,6 +166,7 @@ export default function EditDetails() {
                 value={values.height}
                 onChange={(value) => setFieldValue('height', value)}
                 error={errors.height}
+                disabled={disabledFields.includes('height')}
               />
             </div>
             <div className="w-1/2 pr-5">
@@ -151,6 +177,7 @@ export default function EditDetails() {
                 value={values.fullLineValue}
                 onChange={(value) => setFieldValue('fullLineValue', value)}
                 error={errors.fullLineValue}
+                disabled={disabledFields.includes('fullLineValue')}
               />
             </div>
           </Form>

--- a/frontend/src/app/[locale]/bingo/[bingoId]/actions/end-bingo.tsx
+++ b/frontend/src/app/[locale]/bingo/[bingoId]/actions/end-bingo.tsx
@@ -1,0 +1,30 @@
+import { useTranslations } from 'next-intl';
+
+import Modal from '@/design-system/components/modal';
+import { Button } from '@/design-system/ui/button';
+
+import { useActionsContext } from './provider';
+
+export default function EndBingo() {
+  const { currentAction, closeAction, endBingo } = useActionsContext();
+  const t = useTranslations('bingo.bingoCard.endBingo');
+
+  return (
+    <Modal open={currentAction === 'end'} onOpenChange={closeAction}>
+      <Modal.Header title={t('title')} />
+      <Modal.Body>
+        {t.rich('descriptionHtml', {
+          p: (chunks) => <p className="text-sm text-muted-foreground">{chunks}</p>,
+        })}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="default" onClick={() => endBingo({ input: undefined })}>
+          {t('submit')}
+        </Button>
+        <Button variant="outline" onClick={closeAction}>
+          {t('cancel')}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/frontend/src/app/[locale]/bingo/[bingoId]/actions/reset-bingo.tsx
+++ b/frontend/src/app/[locale]/bingo/[bingoId]/actions/reset-bingo.tsx
@@ -1,0 +1,109 @@
+import { formatDate } from 'date-fns';
+import { Form, FormikContext, useFormik } from 'formik';
+import { MoveRightIcon } from 'lucide-react';
+import { useLocale, useTranslations } from 'next-intl';
+
+import DateField from '@/design-system/components/date-field';
+import Modal from '@/design-system/components/modal';
+import SwitchField from '@/design-system/components/switch-field';
+import { Button } from '@/design-system/ui/button';
+
+import { useActionsContext } from './provider';
+import type { ResetBingoFormValues } from './types';
+
+export default function ResetBingo() {
+  const { currentAction, closeAction, resetBingo } = useActionsContext();
+  const t = useTranslations('bingo.bingoCard.resetBingo');
+  const locale = useLocale();
+
+  const today = formatDate(new Date(), 'yyyy-MM-dd');
+  const formik = useFormik<ResetBingoFormValues>({
+    initialValues: {
+      startDate: today,
+      endDate: today,
+      maxRegistrationDate: today,
+      deleteTiles: false,
+      deleteTeams: false,
+      deleteParticipants: false,
+    },
+    onSubmit: (values, { setErrors }) => resetBingo({ input: values, setErrors }),
+  });
+
+  const { values, errors, setFieldValue, resetForm, submitForm } = formik;
+
+  const handleCancel = () => {
+    resetForm();
+    closeAction();
+  };
+
+  return (
+    <Modal open={currentAction === 'reset'} onOpenChange={handleCancel}>
+      <Modal.Header title={t('title')} />
+      <FormikContext.Provider value={formik}>
+        <Modal.Body>
+          {t.rich('descriptionHtml', {
+            p: (chunks) => <p className="text-sm text-muted-foreground">{chunks}</p>,
+          })}
+          <Form>
+            <div className="flex items-center gap-2.5 w-full">
+              <DateField
+                name="startDate"
+                locale={locale}
+                label={t('form.startDate')}
+                value={values.startDate ?? ''}
+                onChange={(value) => setFieldValue('startDate', value)}
+                error={errors.startDate}
+                modal
+              />
+              <MoveRightIcon className="size-6 mt-1 shrink-0 text-gray-500" />
+              <DateField
+                name="endDate"
+                locale={locale}
+                label={t('form.endDate')}
+                value={values.endDate ?? ''}
+                onChange={(value) => setFieldValue('endDate', value)}
+                error={errors.endDate}
+                modal
+              />
+            </div>
+            <DateField
+              name="maxRegistrationDate"
+              locale={locale}
+              label={t('form.maxRegistrationDate')}
+              value={values.maxRegistrationDate ?? ''}
+              onChange={(value) => setFieldValue('maxRegistrationDate', value)}
+              error={errors.maxRegistrationDate}
+            />
+            <p className="text-sm text-muted-foreground">{t('form.entitiesToClear')}</p>
+            <SwitchField
+              name="deleteTiles"
+              label={t('form.deleteTiles')}
+              value={values.deleteTiles}
+              onChange={(value) => setFieldValue('deleteTiles', value)}
+            />
+            <SwitchField
+              name="deleteTeams"
+              label={t('form.deleteTeams')}
+              value={values.deleteTeams}
+              onChange={(value) => setFieldValue('deleteTeams', value)}
+            />
+            <SwitchField
+              name="deleteParticipants"
+              label={t('form.deleteParticipants')}
+              value={values.deleteParticipants}
+              onChange={(value) => setFieldValue('deleteParticipants', value)}
+            />
+          </Form>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="default" onClick={submitForm}>
+            {t('submit')}
+          </Button>
+          <Button variant="outline" onClick={handleCancel}>
+            {t('cancel')}
+          </Button>
+        </Modal.Footer>
+      </FormikContext.Provider>
+    </Modal>
+  );
+}

--- a/frontend/src/app/[locale]/bingo/[bingoId]/actions/start-bingo.tsx
+++ b/frontend/src/app/[locale]/bingo/[bingoId]/actions/start-bingo.tsx
@@ -1,0 +1,70 @@
+import { Form, FormikContext, useFormik } from 'formik';
+import { useLocale, useTranslations } from 'next-intl';
+
+import DateField from '@/design-system/components/date-field';
+import Modal from '@/design-system/components/modal';
+import SwitchField from '@/design-system/components/switch-field';
+import { Button } from '@/design-system/ui/button';
+
+import { useActionsContext } from './provider';
+import type { StartBingoFormValues } from './types';
+
+export default function StartBingo() {
+  const { bingo, currentAction, closeAction, startBingo } = useActionsContext();
+  const t = useTranslations('bingo.bingoCard.startBingo');
+  const locale = useLocale();
+
+  const formik = useFormik<StartBingoFormValues>({
+    initialValues: { endDate: undefined },
+    onSubmit: (values, { setErrors }) => startBingo({ input: { endDate: values.endDate ?? undefined }, setErrors }),
+  });
+
+  const { values, errors, setFieldValue, resetForm, submitForm } = formik;
+
+  const handleCancel = () => {
+    resetForm();
+    closeAction();
+  };
+
+  const handleSwitchChange = (checked: boolean) => {
+    setFieldValue('endDate', checked ? bingo.endDate : undefined);
+  };
+
+  return (
+    <Modal open={currentAction === 'start'} onOpenChange={handleCancel}>
+      <Modal.Header title={t('title')} />
+      <FormikContext.Provider value={formik}>
+        <Modal.Body>
+          {t.rich('descriptionHtml', {
+            p: (chunks) => <p className="text-sm text-muted-foreground">{chunks}</p>,
+          })}
+          <Form>
+            <SwitchField
+              name="endDate"
+              label={t('endDate.switch')}
+              value={values.endDate !== undefined}
+              onChange={handleSwitchChange}
+            >
+              <DateField
+                name="endDate"
+                locale={locale}
+                value={values.endDate ?? ''}
+                onChange={(value) => setFieldValue('endDate', value)}
+                error={errors.endDate}
+                placeholder={t('endDate.placeholder')}
+              />
+            </SwitchField>
+          </Form>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="default" onClick={submitForm}>
+            {t('submit')}
+          </Button>
+          <Button variant="outline" onClick={handleCancel}>
+            {t('cancel')}
+          </Button>
+        </Modal.Footer>
+      </FormikContext.Provider>
+    </Modal>
+  );
+}

--- a/frontend/src/app/[locale]/bingo/[bingoId]/actions/types.ts
+++ b/frontend/src/app/[locale]/bingo/[bingoId]/actions/types.ts
@@ -1,16 +1,21 @@
 import type { FormikErrors } from 'formik';
-import type { PropsWithChildren } from 'react';
+import { type PropsWithChildren } from 'react';
 
-import type { UpdateBingoDto, BingoDto } from '@/api/types';
+import type { UpdateBingoDto, BingoDto, StartBingoDto, ShortBingoDto, ResetBingoDto } from '@/api/types';
 
 import { type ACTION_KEYS } from './constants';
 
 export type ActionKey = (typeof ACTION_KEYS)[number];
 
+export type ActionVisibleParams = {
+  bingo: BingoDto;
+  participant: ShortBingoDto | undefined;
+};
+
 export type Action = {
   key: ActionKey;
-  visible: (bingo: BingoDto) => boolean;
   variant?: 'destructive';
+  visible: (params: ActionVisibleParams) => boolean;
   icon: React.ComponentType<{ className?: string }>;
 };
 
@@ -18,23 +23,39 @@ export type ActionHandler<Input> = ({ input, setErrors }: { input: Input; setErr
 
 export type ActionsContextType = {
   bingo: BingoDto;
+  participant: ShortBingoDto | undefined;
   currentAction: ActionKey | null;
   updateBingo: ActionHandler<UpdateBingoDto>;
+  startBingo: ActionHandler<StartBingoDto>;
+  endBingo: ActionHandler<void>;
+  cancelBingo: ActionHandler<void>;
+  deleteBingo: ActionHandler<void>;
+  resetBingo: ActionHandler<ResetBingoDto>;
   closeAction: () => void;
   callAction: (actionKey: ActionKey) => void;
 };
 
-export type ActionsProps = {
-  bingo: BingoDto;
-};
-
 export type ActionsProviderProps = PropsWithChildren<{
   bingo: BingoDto;
+  participant: ShortBingoDto | undefined;
 }>;
 
 export type ErrorHandler = (errors: FormikErrors<unknown>) => void;
 
-export type FormValues = Exclude<UpdateBingoDto, 'width' | 'height' | 'fullLineValue'> & {
+export type ResetBingoFormValues = {
+  startDate: string;
+  endDate: string;
+  maxRegistrationDate: string;
+  deleteTiles: boolean;
+  deleteTeams: boolean;
+  deleteParticipants: boolean;
+};
+
+export type StartBingoFormValues = {
+  endDate: string | null | undefined;
+};
+
+export type UpdateBingoFormValues = Exclude<UpdateBingoDto, 'width' | 'height' | 'fullLineValue'> & {
   width: number | null;
   height: number | null;
   fullLineValue: number | null;

--- a/frontend/src/app/[locale]/bingo/[bingoId]/bingo-card/tile.tsx
+++ b/frontend/src/app/[locale]/bingo/[bingoId]/bingo-card/tile.tsx
@@ -62,7 +62,7 @@ export default function Tile({ x, y }: TileProps) {
 
   const isOrganizerOrOwner = role === BingoRoles.Organizer || role === BingoRoles.Owner;
 
-  const ViewOrEditIcon = isOrganizerOrOwner ? PencilIcon : InfoIcon;
+  const ViewOrEditIcon = readOnly ? InfoIcon : PencilIcon;
 
   const mode = (() => {
     if (readOnly) return 'view';
@@ -107,7 +107,7 @@ export default function Tile({ x, y }: TileProps) {
                 <button className={styles.hover.actionButton} onClick={() => viewOrEditTile({ x, y })}>
                   <ViewOrEditIcon className={styles.hover.buttonIcon} />
                 </button>
-                {isOrganizerOrOwner && (
+                {!readOnly && (
                   <button className={styles.hover.actionButton} onClick={() => deleteBingoTile()}>
                     <TrashIcon className={styles.hover.buttonIcon} />
                   </button>

--- a/frontend/src/app/[locale]/bingo/[bingoId]/page.tsx
+++ b/frontend/src/app/[locale]/bingo/[bingoId]/page.tsx
@@ -8,7 +8,7 @@ import { getBingo, listBingoTiles } from '@/api/bingo';
 import { BingoRoles, BingoStatus } from '@/api/types';
 import NotCurrentBingoTip from '@/common/bingo/not-current-bingo-tip';
 import BingoStatusBadge from '@/common/bingo/status-badge';
-import { type ServerSideRootProps } from '@/common/types';
+import type { ServerSideRootProps } from '@/common/types';
 import { formatDateToLocale } from '@/common/utils/date';
 import Avatar from '@/design-system/components/avatar';
 import { Title } from '@/design-system/components/title';
@@ -52,56 +52,52 @@ export default async function BingoCardPage({ params }: ServerSideRootProps<Para
 
   const readOnlyCard = !isCurrentBingoOrganizer || bingo.status !== BingoStatus.Pending;
 
-  console.log({ isBingoOrganizer, isCurrentBingoOrganizer });
-
   return (
     <Fragment>
-      <div className="max-w-5xl">
-        <NotCurrentBingoTip
-          role={currentBingoParticipation?.role}
-          bingoId={bingoId}
-          visible={Boolean(!isCurrentBingoOrganizer && isBingoOrganizer)}
-        />
-        <BingoStatusBadge status={bingo.status} className="mb-2" />
-        <div className="w-full flex items-center justify-between mb-8">
-          <Title.Primary className="!mb-0">{bingo.title}</Title.Primary>
-          {isCurrentBingoOrganizer && <Actions bingo={bingo} />}
-        </div>
-        <div className="flex items-center gap-2.5 mb-2">
-          <CalendarDaysIcon className="size-4" />
+      <NotCurrentBingoTip
+        role={currentBingoParticipation?.role}
+        bingoId={bingoId}
+        visible={Boolean(!isCurrentBingoOrganizer && isBingoOrganizer)}
+      />
+      <BingoStatusBadge status={bingo.status} className="mb-2" />
+      <div className="w-full flex items-center justify-between mb-8">
+        <Title.Primary className="!mb-0">{bingo.title}</Title.Primary>
+        <Actions bingo={bingo} participant={currentBingoParticipation} />
+      </div>
+      <div className="flex items-center gap-2.5 mb-2">
+        <CalendarDaysIcon className="size-4" />
+        <span className="text-sm font-medium">
+          {t.rich('dateRangeHtml', {
+            startDate: formatDateToLocale(bingo.startDate, locale),
+            endDate: formatDateToLocale(bingo.endDate, locale),
+            b: (chunks) => <b>{chunks}</b>,
+          })}
+        </span>
+      </div>
+      {bingo.maxRegistrationDate && (
+        <div className="flex items-center gap-2.5 mb-6">
+          <CalendarCheckIcon className="size-4" />
           <span className="text-sm font-medium">
-            {t.rich('dateRangeHtml', {
-              startDate: formatDateToLocale(bingo.startDate, locale),
-              endDate: formatDateToLocale(bingo.endDate, locale),
+            {t.rich('maxRegistrationDateHtml', {
+              maxRegistrationDate: formatDateToLocale(bingo.maxRegistrationDate, locale),
               b: (chunks) => <b>{chunks}</b>,
             })}
           </span>
         </div>
-        {bingo.maxRegistrationDate && (
-          <div className="flex items-center gap-2.5 mb-6">
-            <CalendarCheckIcon className="size-4" />
-            <span className="text-sm font-medium">
-              {t.rich('maxRegistrationDateHtml', {
-                maxRegistrationDate: formatDateToLocale(bingo.maxRegistrationDate, locale),
-                b: (chunks) => <b>{chunks}</b>,
-              })}
-            </span>
-          </div>
-        )}
-        {bingo.createdBy && (
-          // TODO: add system avatar fallback
-          <div className="flex items-center gap-2 mb-6">
-            <Avatar size={24} user={bingo.createdBy} />
-            <span className="text-sm font-medium">
-              {t.rich('createdByHtml', {
-                username: bingo.createdBy.username,
-                b: (chunks) => <b>{chunks}</b>,
-              })}
-            </span>
-          </div>
-        )}
-        {bingo.description !== '' && <p>{bingo.description}</p>}
-      </div>
+      )}
+      {bingo.createdBy && (
+        // TODO: add system avatar fallback
+        <div className="flex items-center gap-2 mb-6">
+          <Avatar size={24} user={bingo.createdBy} />
+          <span className="text-sm font-medium">
+            {t.rich('createdByHtml', {
+              username: bingo.createdBy.username,
+              b: (chunks) => <b>{chunks}</b>,
+            })}
+          </span>
+        </div>
+      )}
+      {bingo.description !== '' && <p>{bingo.description}</p>}
       <Title.Secondary>Bingo Card</Title.Secondary>
       <BingoCard
         role={user?.currentBingo?.id === bingoId ? currentBingoParticipation?.role : undefined}

--- a/frontend/src/common/select-bingo.tsx
+++ b/frontend/src/common/select-bingo.tsx
@@ -29,6 +29,8 @@ type SelectBingoValueDisplayProps = {
 };
 
 function SelectBingoValueDisplay({ title, status }: SelectBingoValueDisplayProps) {
+  const t = useTranslations('bingo.status');
+
   const statusColor = (() => {
     switch (status) {
       case BingoStatus.Canceled:
@@ -46,12 +48,12 @@ function SelectBingoValueDisplay({ title, status }: SelectBingoValueDisplayProps
 
   return (
     <div className="flex items-center gap-2">
-      {statusColor && (
+      {status && statusColor && (
         <Tooltip>
           <TooltipTrigger asChild>
             <div className={`w-2 h-2 rounded-full ${statusColor}`} />
           </TooltipTrigger>
-          <TooltipContent>{status}</TooltipContent>
+          <TooltipContent>{t(status)}</TooltipContent>
         </Tooltip>
       )}
       {title}
@@ -91,9 +93,8 @@ export default function SelectBingo() {
         return;
       }
 
-      // TODO: if bingoId in route, redirect to the dashboard
       await refreshUser();
-      router.refresh();
+      router.push(`/bingo/${bingo.id}`);
     },
   });
 

--- a/frontend/src/i18n/en/bingo.json
+++ b/frontend/src/i18n/en/bingo.json
@@ -25,8 +25,8 @@
       "editDetails": "Edit details",
       "delete": "Delete event",
       "reset": "Reset event",
-      "startNow": "Start now",
-      "endNow": "End now",
+      "start": "Start now",
+      "end": "End now",
       "cancel": "Cancel event"
     },
     "deleteBingoTile": {
@@ -55,6 +55,54 @@
         "title": "Confirm tile deletion?",
         "confirm": "Confirm"
       }
+    },
+    "startBingo": {
+      "title": "Start the event early?",
+      "descriptionHtml": "<p>You will not be able to change the event's language or public status anymore, or change the Bingo card size and its tiles.</p><p>All pending applications and invitations will be canceled and participants will be locked to their assigned team.</p><p>All participants will be locked to their assigned team and notified that the event is started.</p>",
+      "endDate": {
+        "switch": "I also want to change the end date",
+        "placeholder": "Enter a new end date"
+      },
+      "submit": "Start the event",
+      "cancel": "Close",
+      "success": "Event started successfully."
+    },
+    "endBingo": {
+      "title": "End the event early?",
+      "descriptionHtml": "<p>You will not be able to change the event's title and description anymore.</p><p>All pending tile completion requests will be canceled and the scores will be calculated one last time.</p>",
+      "submit": "End the event",
+      "cancel": "Close",
+      "success": "Event ended successfully."
+    },
+    "cancelBingo": {
+      "title": "Cancel the event?",
+      "descriptionHtml": "<p>You will not be able to change the event details or its Bingo card anymore.</p><p>All applications & invitations, as well as tile completions will be deleted and the team scores will be reset.</p><p>You may still reuse this event's details, bingo card, teams and participants later if you choose to reset it.</p>",
+      "submit": "Cancel the event",
+      "cancel": "Close",
+      "success": "Event canceled successfully."
+    },
+    "deleteBingo": {
+      "title": "Delete the event?",
+      "description": "Participants will not be notified of this action, and the event will be deleted permanently. Are you sure you want to delete it?",
+      "submit": "Yes, delete the event",
+      "cancel": "Close",
+      "success": "Event deleted successfully."
+    },
+    "resetBingo": {
+      "title": "Reset the event?",
+      "descriptionHtml": "<p>Resetting an event allows you to reuse its settings — including the Bingo card, teams, and participants. The event will be set back to Pending status.</p><p>You'll need to choose a new start and end date. You can also set an optional registration deadline. These can be changed later if needed.</p>",
+      "form": {
+        "startDate": "Start date",
+        "endDate": "End date",
+        "maxRegistrationDate": "Registration deadline (optional)",
+        "entitiesToClear": "Optional — choose what you want to be cleared when resetting the event:",
+        "deleteTiles": "Delete all the tiles from the bingo card",
+        "deleteTeams": "Delete all teams",
+        "deleteParticipants": "Remove all participants"
+      },
+      "submit": "Reset the event",
+      "cancel": "Close",
+      "success": "Event reset successfully."
     },
     "moveBingoTileSuccess": "Bingo tile moved successfully.",
     "viewOrEditTile": {

--- a/frontend/src/i18n/fr/bingo.json
+++ b/frontend/src/i18n/fr/bingo.json
@@ -55,6 +55,52 @@
         "confirm": "Confirmer"
       }
     },
+    "startBingo": {
+      "title": "Démarrer l'événement en avance ?",
+      "description": "Vous ne pourrez plus modifier la langue ou le statut public de l'événement, ou modifier la taille de la carte de bingo et ses cases.\n\nToutes les demandes et invitations en attente seront annulées et les participants seront liés à leur équipe assignée.\n\nTous les participants seront liés à leur équipe et notifiés que l'événement a commencé.",
+      "endDate": {
+        "switch": "Je veux aussi modifier la date de fin",
+        "placeholder": "Entrer une nouvelle date de fin"
+      },
+      "success": "L'événement a été démarré avec succès."
+    },
+    "endBingo": {
+      "title": "Terminer l'événement en avance ?",
+      "descriptionHtml": "<p>Vous ne pourrez plus modifier le titre ou la description de l'événement.</p><p>Toutes les demandes de complétion de cases en attente seront annulées et les scores seront calculés une dernière fois.</p>",
+      "submit": "Terminer l'événement",
+      "cancel": "Fermer",
+      "success": "L'événement a été terminé avec succès."
+    },
+    "cancelBingo": {
+      "title": "Annuler l'événement ?",
+      "descriptionHtml": "<p>Vous ne pourrez plus modifier les détails de l'événement ou la carte de bingo.</p><p>Toutes les demandes d'inscription et les invitations en attente, ainsi que les demandes de complétion de cases seront supprimées et les scores des équipes seront réinitialisés.</p><p>Vous pouvez toujours réutiliser les détails, la carte de bingo, les équipes et les participants de cet événement plus tard si vous choisissez de le réinitialiser.</p>",
+      "submit": "Annuler l'événement",
+      "cancel": "Fermer",
+      "success": "L'événement a été annulé avec succès."
+    },
+    "deleteBingo": {
+      "title": "Supprimer l'événement ?",
+      "description": "Les participants ne seront pas notifiés de cette action, et l'événement sera supprimé définitivement. Êtes-vous sûr de vouloir le supprimer ?",
+      "submit": "Oui, supprimer l'événement",
+      "cancel": "Fermer",
+      "success": "L'événement a été supprimé avec succès."
+    },
+    "resetBingo": {
+      "title": "Réinitialiser l'événement ?",
+      "descriptionHtml": "<p>Réinitialiser un événement permet de réutiliser ses paramètres, y compris la carte de bingo, les équipes et les participants. L'événement sera remis à l'état En attente.</p><p>Vous devrez choisir une nouvelle date de début et de fin. Vous pouvez également définir une date limite d'inscription optionnelle. Ces paramètres peuvent être modifiés plus tard si nécessaire.</p>",
+      "form": {
+        "startDate": "Date de début",
+        "endDate": "Date de fin",
+        "maxRegistrationDate": "Date limite d'inscription (optionnel)",
+        "entitiesToClear": "Optionnel — choisissez ce que vous souhaitez réinitialiser lors de la réinitialisation de l'événement :",
+        "deleteTiles": "Supprimer toutes les cases de la carte de bingo",
+        "deleteTeams": "Supprimer toutes les équipes",
+        "deleteParticipants": "Supprimer tous les participants"
+      },
+      "submit": "Réinitialiser l'événement",
+      "cancel": "Fermer",
+      "success": "L'événement a été réinitialisé avec succès."
+    },
     "moveBingoTileSuccess": "La case de bingo a été déplacée avec succès.",
     "viewOrEditTile": {
       "title": {


### PR DESCRIPTION
[![Issue](https://img.shields.io/github/issues/detail/title/RuneBingo/RuneBingo/60?label=%2360&color=blue)](https://github.com/RuneBingo/RuneBingo/issues/60)

<details>
<summary><h2>Screenshots</h2></summary>

![image](https://github.com/user-attachments/assets/1ea8bb4a-82ab-46ca-80eb-f955363dfc0a)

![image](https://github.com/user-attachments/assets/94540642-108a-4b6e-bace-b29cfb6a25cc)

![image](https://github.com/user-attachments/assets/a69c6b2d-d395-4be1-ba4a-f30a12d0bc1e)

![image](https://github.com/user-attachments/assets/bfa9808e-fac5-4b46-9b5f-9de0836012b9)

![image](https://github.com/user-attachments/assets/0ab8bb5b-34d1-418f-bfc0-893477fb1b28)

</details>

## Description

This PR allows bingo organizers to manage the life cycle of their bingo events via the Bingo's page.

Organizers may start a pending event early, as well as edit the end date at the same time. They may also end an ongoing event early.

Owners may cancel a pending or ongoing event, as well as reset it once it has been canceled. They can choose to delete or keep certain elements while resetting it, such as teams, participants or tiles.

### How to test

The user `raph` has a `ready_bingo` and a `lifecycle-bingo` for testing purposes. You can use the `ready_bingo` to go through a whole life cycle, or just use the `lifecycle-bingo` to test cancelation and reset.

### Test cases

<!-- Add test cases that cover your changes -->

- [ ] Starting a bingo early changes the start date, as well as changing the end date if specified by the user.
- [ ] Ending a bingo early works without errors.
- [ ] Canceling a bingo works without errors.
- [ ] Resetting allows changing the dates and specifying some entities to delete. Refer to the tests for more cases, but they should all be covered! 🧪 
