### PR TITLE
Add custom 404 page with translations (fr/en) to catch all non-valid …

### DIFF
--- a/frontend/src/app/[locale]/[...notFound]/page.tsx
+++ b/frontend/src/app/[locale]/[...notFound]/page.tsx
@@ -1,0 +1,12 @@
+import NotFound from "../not-found";
+import Navbar from "@/common/navbar";
+
+
+export default function CacthAllNotFoundPage(){
+    return (
+        <>
+            <Navbar mode="site"/>
+            <NotFound/>
+        </>
+    );
+}

--- a/frontend/src/app/[locale]/not-found.tsx
+++ b/frontend/src/app/[locale]/not-found.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link'
+import { getTranslations } from 'next-intl/server';
+import { Button } from '@/design-system/ui/button';
+
+
+export default async function NotFound() {
+  const t = await getTranslations('site.errors.404');
+
+return (
+  <div>
+    <h2>{t('title')}</h2>
+    <p>{t('description')}</p>
+    
+    <Link href="/en">
+      <Button className="w-full" type="button">
+              {t('returnHome')}
+      </Button>
+    </Link>
+  </div>
+)
+
+}

--- a/frontend/src/app/[locale]/page.tsx
+++ b/frontend/src/app/[locale]/page.tsx
@@ -1,10 +1,17 @@
 import { type Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
-import { Fragment } from 'react';
+import { Fragment } from 'react'; //react fragment is used to group multiple elements without adding extre HTML around them
 
 import Navbar from '@/common/navbar';
 import Page from '@/design-system/components/page/page';
 
+/*
+Grabs translated text for the page title and description (from your translation files).
+
+Returns metadata that Next.js uses to:
+- Set the browser tab title
+- Set the meta description (for SEO).
+*/
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('site.home.meta');
   const tCommon = await getTranslations('common.meta');

--- a/frontend/src/i18n/en/site.json
+++ b/frontend/src/i18n/en/site.json
@@ -9,5 +9,12 @@
       "subtitle": "RuneBingo - the Open Source platform",
       "description": "A comprehensive solution for event organizers to manage complex events without hassle."
     }
+  },
+  "errors": {
+    "404" : {
+      "title": "Page not Found",
+      "description": "The page you are trying to reach is invalid. ",
+      "returnHome": "Return Home"
+    }
   }
 }

--- a/frontend/src/i18n/fr/site.json
+++ b/frontend/src/i18n/fr/site.json
@@ -9,5 +9,12 @@
       "subtitle": "RuneBingo - la plateforme de bingo open source",
       "description": "Une solution complète pour les organisateurs d'événements afin de gérer facilement des événements complexes."
     }
+  },
+  "errors": {
+    "404" : {
+      "title": "Page non trouvé",
+      "description": "La page que vous cherché est invalide. ",
+      "returnHome": "Retourner à l'accueil"
+    }
   }
 }


### PR DESCRIPTION
## Ajouter une page 404 personnalisée avec traductions et mise en page

- Implémente un composant **not-found.tsx** pour gérer les erreurs 404 à l’aide de la fonction notFound() de Next.js.

- Ajoute une route de type catch-all **[...notFound]/page.tsx** pour intercepter les chemins inconnus et rediriger vers la page 404 personnalisée.
 
- Intègre la prise en charge des traductions pour la page 404 via **getTranslations('errors.404')** (j’ai ajouté une section dans le fichier JSON pour faciliter la gestion d'autres erreurs au besoin).
 
- Inclut la barre de navigation du site 
 

P.s : le styling de la page n'a pas vraiment été modifié. Donc ce serait à faire en temps et lieu, mais le contenu est là et la redirection fonctionne :) 